### PR TITLE
Use local time for on this day

### DIFF
--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -117,9 +117,13 @@ export default {
         );
     },
     albumsOnThisDay: (state, getters, rootState) => {
-      const today = new Date(rootState.currentDay).toISOString().slice(5, 10);
+      const today = new Date(rootState.currentDay);
       return getters.albums
-        .filter((r) => `${r.release.slice(-5)}` === today)
+        .filter(
+          (r) =>
+            `${r.release.slice(-5)}` ===
+            `${today.getMonth() + 1}-${today.getDate()}`
+        )
         .sort(
           (a1, a2) =>
             compareStrings(a1.release, a2.release) ||


### PR DESCRIPTION
`toISOString` returns the day formatted in UTC, while `setHours` operates on local time. This resulted in the string returned by `toISOString` to be `"2020-03-26T23:00:00.000Z"` when in CET, resulting in the albums of the previous day being shown.