### PR TITLE
Avoid having the same key in one view

### DIFF
--- a/src/views/artists/Artists.vue
+++ b/src/views/artists/Artists.vue
@@ -38,7 +38,7 @@
         <VRow>
           <VCol
             v-for="item in props.items"
-            :key="item.name"
+            :key="item.id"
             cols="12"
             sm="6"
             md="4"

--- a/src/views/flags/Flags.vue
+++ b/src/views/flags/Flags.vue
@@ -16,7 +16,7 @@
           <VRow>
             <VCol
               v-for="item in props.items"
-              :key="item.name"
+              :key="`artist${item.id}`"
               lg="3"
               md="4"
               sm="6"
@@ -44,7 +44,7 @@
           <VRow>
             <VCol
               v-for="item in props.items"
-              :key="item.name"
+              :key="`album${item.id}`"
               lg="3"
               md="4"
               sm="6"

--- a/src/views/labels/Labels.vue
+++ b/src/views/labels/Labels.vue
@@ -29,7 +29,7 @@
       <template v-slot:default="props">
         <VRow>
           <VCol
-            :key="item.name"
+            :key="item.id"
             lg="3"
             md="4"
             sm="6"


### PR DESCRIPTION
Fix #38

The problem was that we used the the artist's name as a key. Once we had two artists with the exact same name, it didn't know which one to change if the DOM was updated.

I've made sure we always use a unique identifier as a key. This is usually the id (as we already did most of the time), except when we have two different data-sets in one view (since, in theory, we could end up with an artist and an album with the same id).