### PR TITLE
Warn user if they are using console or debugger

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,8 +9,8 @@ module.exports = {
     "vuetify/no-deprecated-classes": "error",
     "vuetify/grid-unknown-attributes": "error",
     "vuetify/no-legacy-grid": "error",
-    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
-    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
+    "no-console": process.env.NODE_ENV === "production" ? "error" : "warn",
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "warn",
   },
   parserOptions: {
     parser: "babel-eslint",


### PR DESCRIPTION
Since console and debugger will give an error in production, we should warn the user when using them. (Mostly so they know to remove this before commiting changes).