### PR TITLE
Check if we are playing before sending error

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -309,7 +309,7 @@ export default {
       }
     },
     onAudioError(event) {
-      if (event.srcElement.networkState === 3) {
+      if (this.playing && event.srcElement.networkState === 3) {
         this.nextTrack();
         this.$store.commit("addError", {
           playlist: ["player.track-skipped"],


### PR DESCRIPTION
Fix #97 

After the playlist ended it set the current track to `-1` making the source look for `/app/null`.
I've added the requirement that we should be playing. This should never give an error when not playing.