### PR TITLE
Prevent user from playing or adding when there will be no result

### DIFF
--- a/src/components/AlbumActions.vue
+++ b/src/components/AlbumActions.vue
@@ -1,25 +1,42 @@
 <template>
   <span>
-    <VBtn
-      @click.stop.prevent="startTracks"
-      color="primary"
-      class="ma-2"
-      text
-      icon
-      small
-    >
-      <VIcon>mdi-play</VIcon>
-    </VBtn>
-    <VBtn
-      @click.stop.prevent="addTracks"
-      color="success"
-      class="ma-2"
-      text
-      icon
-      small
-    >
-      <VIcon>mdi-plus</VIcon>
-    </VBtn>
+    <VTooltip bottom :disabled="playableTracks.length !== 0">
+      <template v-slot:activator="{ on }">
+        <span v-on="on">
+          <VBtn
+            @click.stop.prevent="startTracks"
+            :disabled="playableTracks.length === 0"
+            color="primary"
+            class="ma-2"
+            text
+            icon
+            small
+          >
+            <VIcon>mdi-play</VIcon>
+          </VBtn>
+        </span>
+      </template>
+      <span>{{ $t("music.album.no-tracks-to-play") }}</span>
+    </VTooltip>
+    <VTooltip bottom :disabled="playableTracks.length !== 0">
+      <template v-slot:activator="{ on }">
+        <span v-on="on">
+          <VBtn
+            @click.stop.prevent="addTracks"
+            :disabled="playableTracks.length === 0"
+            color="success"
+            class="ma-2"
+            text
+            icon
+            small
+            v-on="on"
+          >
+            <VIcon>mdi-plus</VIcon>
+          </VBtn>
+        </span>
+      </template>
+      <span>{{ $t("music.album.no-tracks-to-add") }}</span>
+    </VTooltip>
     <EditReviewComment :item="album" :update="flag" />
     <VBtn
       :to="{
@@ -69,6 +86,11 @@ export default {
       const getter = this.$store.getters["tracks/tracksFilterByAlbum"];
       return getter(this.album.id);
     },
+    playableTracks() {
+      return this.tracks
+        .filter((track) => track.length !== null)
+        .map((obj) => obj.id);
+    },
   },
   methods: {
     ...mapActions("albums", ["destroy", "update"]),
@@ -78,10 +100,7 @@ export default {
       }
     },
     startTracks: function () {
-      const queue = this.tracks
-        .filter((track) => track.length !== null)
-        .map((obj) => obj.id);
-      if (queue.length > 0) {
+      if (this.playableTracks.length > 0) {
         this.$store.commit("player/playTracks", queue);
         if (queue.length !== this.tracks.length) {
           this.$store.commit("addError", {
@@ -95,10 +114,7 @@ export default {
       }
     },
     addTracks: function () {
-      const queue = this.tracks
-        .filter((track) => track.length !== null)
-        .map((obj) => obj.id);
-      if (queue.length > 0) {
+      if (this.playableTracks.length > 0) {
         this.$store.commit("player/addTracks", queue);
         if (queue.length !== this.tracks.length) {
           this.$store.commit("addError", {

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -1,11 +1,41 @@
 <template>
   <span>
-    <VBtn @click="startTrack" color="primary" class="ma-1" text icon small>
-      <VIcon>mdi-play</VIcon>
-    </VBtn>
-    <VBtn @click="addTrack" color="success" class="ma-1" text icon small>
-      <VIcon>mdi-plus</VIcon>
-    </VBtn>
+    <VTooltip bottom :disabled="track.length !== null">
+      <template v-slot:activator="{ on }">
+        <span v-on="on">
+          <VBtn
+            @click="startTrack"
+            :disabled="track.length === null"
+            color="primary"
+            class="ma-1"
+            text
+            icon
+            small
+          >
+            <VIcon>mdi-play</VIcon>
+          </VBtn>
+        </span>
+      </template>
+      <span>{{ $t("music.track.empty") }}</span>
+    </VTooltip>
+    <VTooltip bottom :disabled="track.length !== null">
+      <template v-slot:activator="{ on }">
+        <span v-on="on">
+          <VBtn
+            @click="addTrack"
+            :disabled="track.length === null"
+            color="success"
+            class="ma-1"
+            text
+            icon
+            small
+          >
+            <VIcon>mdi-plus</VIcon>
+          </VBtn>
+        </span>
+      </template>
+      <span>{{ $t("music.track.empty") }}</span>
+    </VTooltip>
     <EditReviewComment :item="track" :update="flag" />
     <VBtn
       :to="{

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -199,6 +199,8 @@
 			"edition-description": "Edition description",
 			"edition-information": "Add edition information",
 			"new": "New album",
+			"no-tracks-to-play": "There are no tracks to play",
+			"no-tracks-to-add": "There are no tracks to add",
 			"original": "Original",
 			"release": "Release",
 			"update": "Update album"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -199,6 +199,8 @@
 			"edition-description": "Beschrijving editie",
 			"edition-information": "Voeg informatie over deze editie toe",
 			"new": "Nieuw album",
+			"no-tracks-to-play": "Er zijn geen nummers om af te spelen",
+			"no-tracks-to-add": "Er zijn geen nummers om toe te voegen",
 			"original": "Origineel",
 			"release": "Uitgave",
 			"update": "Werk album bij"


### PR DESCRIPTION
Rather than displaying an error when there are no tracks to play/add, we should disable the button to do so