### PR TITLE
Refactor api calls to generic functions

### DIFF
--- a/src/api/albums.js
+++ b/src/api/albums.js
@@ -1,73 +1,27 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+  destroyEmpty as genDestroyEmpty,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("albums", auth);
 }
 
 export function create(auth, album) {
-  return fetch(`${baseURL}/albums`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ album }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("albums", auth, album);
 }
 
 export function update(auth, id, album) {
-  return fetch(`${baseURL}/albums/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ album }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`albums/${id}`, auth, album);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/albums/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`albums/${id}`, auth);
 }
 
 export function destroyEmpty(auth) {
-  return fetch(`${baseURL}/albums/destroy_empty`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroyEmpty("albums", auth);
 }

--- a/src/api/artists.js
+++ b/src/api/artists.js
@@ -1,73 +1,27 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+  destroyEmpty as genDestroyEmpty,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("artists", auth);
 }
 
 export function create(auth, artist) {
-  return fetch(`${baseURL}/artists`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ artist }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("artists", auth, artist);
 }
 
 export function update(auth, id, artist) {
-  return fetch(`${baseURL}/artists/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ artist }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`artists/${id}`, auth, artist);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/artists/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`artists/${id}`, auth);
 }
 
 export function destroyEmpty(auth) {
-  return fetch(`${baseURL}/artists/destroy_empty`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroyEmpty("artists", auth);
 }

--- a/src/api/auth_tokens.js
+++ b/src/api/auth_tokens.js
@@ -1,5 +1,5 @@
 import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import { indexGenerator, destroy as genDestroy } from "./fetch";
 
 export function index(auth) {
   return indexGenerator("auth_tokens", auth);
@@ -21,17 +21,5 @@ export function create(data) {
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/auth_tokens/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`auth_tokens/${id}`, auth);
 }

--- a/src/api/codec_conversions.js
+++ b/src/api/codec_conversions.js
@@ -1,56 +1,22 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("codec_conversions", auth);
 }
 
 export function create(auth, codec_conversion) {
-  return fetch(`${baseURL}/codec_conversions`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ codec_conversion }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("codec_conversions", auth, codec_conversion);
 }
 
 export function update(auth, id, codec_conversion) {
-  return fetch(`${baseURL}/codec_conversions/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ codec_conversion }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`codec_conversions/${id}`, auth, codec_conversion);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/codec_conversions/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`codec_conversions/${id}`, auth);
 }

--- a/src/api/codecs.js
+++ b/src/api/codecs.js
@@ -1,56 +1,22 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("codecs", auth);
 }
 
 export function create(auth, codec) {
-  return fetch(`${baseURL}/codecs`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ codec }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("codecs", auth, codec);
 }
 
 export function update(auth, id, codec) {
-  return fetch(`${baseURL}/codecs/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ codec }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`codecs/${id}`, auth, codec);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/codecs/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`codecs/${id}`, auth);
 }

--- a/src/api/cover_filenames.js
+++ b/src/api/cover_filenames.js
@@ -1,56 +1,22 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("cover_filenames", auth);
 }
 
 export function create(auth, cover_filename) {
-  return fetch(`${baseURL}/cover_filenames`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ cover_filename }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("cover_filenames", auth, cover_filename);
 }
 
 export function update(auth, id, cover_filename) {
-  return fetch(`${baseURL}/cover_filenames/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ cover_filename }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`cover_filenames/${id}`, auth, cover_filename);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/cover_filenames/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`cover_filenames/${id}`, auth);
 }

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -29,3 +29,87 @@ export async function* indexGenerator(path, auth) {
     page++;
   }
 }
+
+export function create(path, auth, object) {
+  return fetch(`${baseURL}/${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+    body: JSON.stringify({ object }),
+  })
+    .catch((reason) => Promise.reject({ error: [reason] }))
+    .then((request) => Promise.all([request.ok, request.json()]))
+    .then(([ok, result]) => {
+      return ok ? Promise.resolve(result) : Promise.reject(result);
+    });
+}
+
+export function update(path, auth, object) {
+  return fetch(`${baseURL}/${path}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+    body: JSON.stringify({ object }),
+  })
+    .catch((reason) => Promise.reject({ error: [reason] }))
+    .then((request) => Promise.all([request.ok, request.json()]))
+    .then(([ok, result]) => {
+      return ok ? Promise.resolve(result) : Promise.reject(result);
+    });
+}
+
+export function destroy(path, auth) {
+  return fetch(`${baseURL}/${path}`, {
+    method: "DELETE",
+    headers: {
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+  })
+    .catch((reason) => Promise.reject({ error: [reason] }))
+    .then((request) => {
+      return request.ok
+        ? Promise.resolve()
+        : request.json().then((result) => Promise.reject(result));
+    });
+}
+
+export function destroyEmpty(path, auth) {
+  return fetch(`${baseURL}/${path}/destroy_empty`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+  })
+    .catch((reason) => Promise.reject({ error: [reason] }))
+    .then((request) => {
+      return request.ok
+        ? Promise.resolve()
+        : request.json().then((result) => Promise.reject(result));
+    });
+}
+
+export function merge(path, auth) {
+  return fetch(`${baseURL}/${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+  })
+    .catch((reason) => Promise.reject({ error: [reason] }))
+    .then((request) => {
+      return request.ok
+        ? Promise.resolve()
+        : request.json().then((result) => Promise.reject(result));
+    });
+}

--- a/src/api/genres.js
+++ b/src/api/genres.js
@@ -1,90 +1,32 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+  destroyEmpty as genDestroyEmpty,
+  merge as genMerge,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("genres", auth);
 }
 
 export function create(auth, genre) {
-  return fetch(`${baseURL}/genres`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ genre }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("genres", auth, genre);
 }
 
 export function update(auth, id, genre) {
-  return fetch(`${baseURL}/genres/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ genre }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`genres/${id}`, auth, genre);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/genres/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`genres/${id}`, auth);
 }
 
 export function destroyEmpty(auth) {
-  return fetch(`${baseURL}/genres/destroy_empty`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroyEmpty("genres", auth);
 }
 
 export function merge(auth, newID, oldID) {
-  return fetch(`${baseURL}/genres/${newID}/merge?other_genre_id=${oldID}`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genMerge(`genres/${newID}/merge?other_genre_id=${oldID}`, auth);
 }

--- a/src/api/image_types.js
+++ b/src/api/image_types.js
@@ -1,56 +1,22 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("image_types", auth);
 }
 
 export function create(auth, image_type) {
-  return fetch(`${baseURL}/image_types`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ image_type }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("image_types", auth, image_type);
 }
 
 export function update(auth, id, image_type) {
-  return fetch(`${baseURL}/image_types/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ image_type }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`image_types/${id}`, auth, image_type);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/image_types/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`image_types/${id}`, auth);
 }

--- a/src/api/labels.js
+++ b/src/api/labels.js
@@ -1,90 +1,32 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+  destroyEmpty as genDestroyEmpty,
+  merge as genMerge,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("labels", auth);
 }
 
 export function create(auth, label) {
-  return fetch(`${baseURL}/labels`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ label }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("labels", auth, label);
 }
 
 export function update(auth, id, label) {
-  return fetch(`${baseURL}/labels/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ label }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`labels/${id}`, auth, label);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/labels/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`labels/${id}`, auth);
 }
 
 export function destroyEmpty(auth) {
-  return fetch(`${baseURL}/labels/destroy_empty`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroyEmpty("labels", auth);
 }
 
 export function merge(auth, newID, oldID) {
-  return fetch(`${baseURL}/labels/${newID}/merge?other_label_id=${oldID}`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genMerge(`labels/${newID}/merge?other_label_id=${oldID}`, auth);
 }

--- a/src/api/locations.js
+++ b/src/api/locations.js
@@ -1,39 +1,17 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  destroy as genDestroy,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("locations", auth);
 }
 
 export function create(auth, location) {
-  return fetch(`${baseURL}/locations`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ location }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("locations", auth, location);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/locations/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`locations/${id}`, auth);
 }

--- a/src/api/tracks.js
+++ b/src/api/tracks.js
@@ -1,56 +1,22 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("tracks", auth);
 }
 
 export function create(auth, track) {
-  return fetch(`${baseURL}/tracks`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ track }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("tracks", auth, track);
 }
 
 export function update(auth, id, track) {
-  return fetch(`${baseURL}/tracks/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ track }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`tracks/${id}`, auth, track);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/tracks/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`tracks/${id}`, auth);
 }

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,56 +1,22 @@
-import baseURL from "./base_url";
-import { indexGenerator } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  update as genUpdate,
+  destroy as genDestroy,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("users", auth);
 }
 
 export function create(auth, user) {
-  return fetch(`${baseURL}/users`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ user }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("users", auth, user);
 }
 
 export function update(auth, id, user) {
-  return fetch(`${baseURL}/users/${id}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify({ user }),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genUpdate(`users/${id}`, auth, user);
 }
 
 export function destroy(auth, id) {
-  return fetch(`${baseURL}/users/${id}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return genDestroy(`users/${id}`, auth);
 }


### PR DESCRIPTION
I've reworked almost all api calls to use a generic function. This way we can change the functions with less work and less chance for errors.

Two things I wasn't sure about:
* Naming of the fuctions. I've kept the names in `api/fetch` simple, and renamed the functions on import. A better naming scheme is welcome
* Path in merge: I was doubting to split this into two parts: `${object}/${newID}` and `other_object_id=${oldID}` since we can assume the path to contans `/merge?`. In the end, It seemed better to keep the whole path as a param, to have more consistency accross the functions in `api/fetch`.