### PR TITLE
Always use scss as lang for style

### DIFF
--- a/src/Main.vue
+++ b/src/Main.vue
@@ -4,7 +4,7 @@
   </VApp>
 </template>
 
-<style>
+<style lang="scss">
 a {
   text-decoration: none;
 }

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -592,7 +592,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .review-comment-table td {
   padding: 0 0.5rem;
 }

--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -179,7 +179,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .bottom-padding-fix {
   padding-bottom: 16px;
 }

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -235,7 +235,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .btn-caption {
   font-size: 0.75rem;
 }

--- a/src/views/Library.vue
+++ b/src/views/Library.vue
@@ -128,7 +128,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 pre {
   overflow-x: auto;
 }

--- a/src/views/artists/NewArtist.vue
+++ b/src/views/artists/NewArtist.vue
@@ -42,5 +42,3 @@ export default {
   },
 };
 </script>
-
-<style scoped></style>


### PR DESCRIPTION
I've updated all `style` tags to use scss. Before we had half of them in scss and in css.
For consistency we should always use scss and use scoped except when not possible (this was already the case).