### PR TITLE
Add form validations

### DIFF
--- a/src/components/CoverFilenameForm.vue
+++ b/src/components/CoverFilenameForm.vue
@@ -1,15 +1,18 @@
 <template>
-  <VForm>
+  <VForm v-model="isValid" ref="form" lazy-validation>
     <VRow>
       <VCol cols="5">
         <VTextField
           v-model="newCoverFilename.filename"
           :label="$t('library.filename')"
           :disabled="coverFilename !== null"
+          required
+          :rules="[(v) => !!v || $t('errors.cover_filename.filename-blank')]"
         />
       </VCol>
       <VCol cols="2" sm="1">
         <VBtn
+          :disabled="!isValid"
           icon
           outlined
           color="success"
@@ -45,6 +48,7 @@ export default {
       newCoverFilename: {
         filename: "",
       },
+      isValid: true,
     };
   },
   created() {
@@ -67,11 +71,13 @@ export default {
     },
     ...mapActions("coverFilenames", ["destroy", "update", "create"]),
     saveCoverFilename() {
-      this.create(this.newCoverFilename).then((id) => {
-        if (id) {
-          this.newCoverFilename.filename = "";
-        }
-      });
+      if (this.$refs.form.validate()) {
+        this.create(this.newCoverFilename).then((id) => {
+          if (id) {
+            this.newCoverFilename.filename = "";
+          }
+        });
+      }
     },
     deleteCoverFilename() {
       if (confirm(this.$t("common.are-you-sure"))) {

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -97,6 +97,7 @@
                   v-model="number.amount"
                   :label="$t('common.amount')"
                   type="number"
+                  step="1"
                   v-if="number.enabled"
                   hide-details="true"
                 />
@@ -196,6 +197,8 @@
                   multiple
                   return-object
                   v-model="changeGenres.genres"
+                  :rules="rules.genre"
+                  validate-on-blur
                 />
               </VCol>
             </VRow>
@@ -399,6 +402,35 @@ export default {
     ...mapGetters("genres", {
       sortedGenres: "genresByName",
     }),
+    rules: function () {
+      const rules = {
+        genre: [],
+      };
+
+      const genreValidation = (v) => {
+        let valid = true;
+        v.forEach((newGenre) => {
+          if (typeof newGenre !== "object") {
+            const double = this.sortedGenres.some(
+              (g) =>
+                g.name === newGenre ||
+                g.normalized_name === newGenre.toLowerCase()
+            );
+            if (double) {
+              valid = this.$t("errors.genre.name-taken-obj", { obj: newGenre });
+            } else if (!newGenre.trim().length) {
+              valid = this.$t("errors.genre.name-blank");
+            }
+          }
+        });
+        return valid; // We only return the last error, since we can only display one
+      };
+      if (this.changeGenres.enabled) {
+        rules.genre.push(genreValidation);
+      }
+
+      return rules;
+    },
   },
   methods: {
     ...mapActions("tracks", ["update"]),

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -8,305 +8,311 @@
       </VBtn>
     </template>
     <VCard>
-      <VToolbar dark color="primary" class="flex-grow-0">
-        <VBtn icon dark @click="dialog = false">
-          <VIcon>mdi-close</VIcon>
-        </VBtn>
-        <VToolbarTitle>
-          {{
-            $tc("music.mass.edit-tracks", tracks.length, {
-              count: tracks.length,
-            })
-          }}
-        </VToolbarTitle>
-        <VSpacer></VSpacer>
-        <VToolbarItems>
-          <VBtn icon @click="saveTracks" :disabled="saving">
-            <VIcon>
-              {{ saving ? "mdi-refresh mdi-spin" : "mdi-content-save" }}
-            </VIcon>
+      <VForm v-model="isValid" ref="form">
+        <VToolbar dark color="primary" class="flex-grow-0">
+          <VBtn icon dark @click="dialog = false">
+            <VIcon>mdi-close</VIcon>
           </VBtn>
-        </VToolbarItems>
-      </VToolbar>
-      <div style="overflow-y: auto; backface-visibility: hidden;">
-        <VContainer>
-          <Errors />
-          <VContainer
-            fluid
-            v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
-          >
-            <VRow dense>
-              <VCol cols="12">
-                <VCheckbox v-model="showReviewComments">
-                  <template v-slot:label>
-                    <span class="black--text">
-                      {{
-                        $tc(
-                          "music.flag.show",
-                          tracks.filter((t) => t.review_comment !== null).length
-                        )
-                      }}
-                    </span>
-                  </template>
-                </VCheckbox>
-              </VCol>
-            </VRow>
-            <VRow v-if="showReviewComments">
-              <VCol cols="12">
-                <VAlert
-                  :value="showReviewComments"
-                  type="warning"
-                  icon="mdi-flag"
-                >
-                  <table class="review-comment-table">
-                    <tr
-                      v-for="t of tracks.filter(
-                        (tr) => tr.review_comment !== null
-                      )"
-                      :key="t.id"
-                    >
-                      <td class="text-right">
-                        <strong>{{ t.number }}</strong>
-                      </td>
-                      <td>
-                        <strong>{{ t.title }}</strong>
-                      </td>
-                      <td>{{ t.review_comment }}</td>
-                    </tr>
-                  </table>
-                </VAlert>
-              </VCol>
-            </VRow>
-          </VContainer>
-          <VDivider
-            v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
-          />
-          <VContainer fluid>
-            <VRow dense>
-              <VCol cols="12" sm="6">
-                <VCheckbox v-model="number.enabled">
-                  <template v-slot:label>
-                    <span class="black--text">
-                      {{ $t("music.mass.increase-track") }}
-                    </span>
-                  </template>
-                </VCheckbox>
-              </VCol>
-              <VCol cols="12" sm="6">
-                <VTextField
-                  v-model="number.amount"
-                  :label="$t('common.amount')"
-                  type="number"
-                  step="1"
-                  v-if="number.enabled"
-                  hide-details="true"
-                />
-              </VCol>
-            </VRow>
-          </VContainer>
-          <VDivider />
-          <VContainer fluid>
-            <VRow dense>
-              <VCol cols="12" sm="6">
-                <VCheckbox v-model="titleReplacement.enabled">
-                  <template v-slot:label>
-                    <span class="black--text">
-                      {{ $t("music.mass.title-search") }}
-                    </span>
-                  </template>
-                </VCheckbox>
-              </VCol>
-              <VCol cols="12" sm="6">
-                <VCheckbox
-                  v-model="titleReplacement.regex"
-                  :label="$t('music.mass.regex')"
-                  v-if="titleReplacement.enabled"
-                />
-              </VCol>
-            </VRow>
-            <VRow v-if="titleReplacement.enabled">
-              <VCol cols="12" sm="6">
-                <VTextField
-                  :label="$t('common.search')"
-                  v-model="titleReplacement.search"
-                />
-              </VCol>
-              <VCol cols="12" sm="6">
-                <VTextField
-                  :label="$t('common.replace')"
-                  v-model="titleReplacement.replace"
-                />
-              </VCol>
-            </VRow>
-          </VContainer>
-          <VDivider />
-          <VContainer fluid>
-            <VRow dense>
-              <VCol cols="12" sm="6">
-                <VCheckbox v-model="album.enabled">
-                  <template v-slot:label>
-                    <span class="black--text">
-                      {{ $t("music.mass.set-album") }}
-                    </span>
-                  </template>
-                </VCheckbox>
-              </VCol>
-              <VCol cols="12" sm="6">
-                <VAutocomplete
-                  :items="sortedAlbums"
-                  item-text="title"
-                  item-value="id"
-                  label="Album"
-                  hide-details="true"
-                  v-model="album.album"
-                  v-if="album.enabled"
-                />
-              </VCol>
-            </VRow>
-          </VContainer>
-          <VDivider />
-          <VContainer fluid>
-            <VRow dense>
-              <VCol cols="12" sm="6">
-                <VCheckbox v-model="changeGenres.enabled">
-                  <template v-slot:label>
-                    <span class="black--text">
-                      {{ $t("music.mass.change-genres") }}
-                    </span>
-                  </template>
-                </VCheckbox>
-              </VCol>
-              <VCol cols="12" sm="6">
-                <VCheckbox
-                  v-model="changeGenres.replace"
-                  :label="$t('music.mass.replace-instead-genres')"
-                  v-if="changeGenres.enabled"
-                />
-              </VCol>
-            </VRow>
-            <VRow v-if="changeGenres.enabled">
-              <VCol cols="12" sm="6">
-                <VCombobox
-                  :items="sortedGenres"
-                  cache-items
-                  chips
-                  deletable-chips
-                  item-text="name"
-                  item-value="id"
-                  :label="$t('music.genre-s')"
-                  multiple
-                  return-object
-                  v-model="changeGenres.genres"
-                  :rules="rules.genre"
-                  validate-on-blur
-                />
-              </VCol>
-            </VRow>
-          </VContainer>
-          <VDivider />
-          <VContainer fluid>
-            <VRow dense>
-              <VCol cols="12" sm="6">
-                <VCheckbox v-model="changeArtists.enabled">
-                  <template v-slot:label>
-                    <span class="black--text">
-                      {{ $t("music.mass.change-artists") }}
-                    </span>
-                  </template>
-                </VCheckbox>
-              </VCol>
-              <VCol cols="12" sm="6">
-                <VCheckbox
-                  v-model="changeArtists.replace"
-                  :label="$t('music.mass.replace-instead-artists')"
-                  v-if="changeArtists.enabled"
-                />
-              </VCol>
-            </VRow>
-            <VRow
-              :key="index"
-              v-for="(item, index) of changeArtists.track_artists"
-              no-gutters
-            >
-              <VCol class="flex-column no-grow" v-if="changeArtists.enabled">
-                <VBtn
-                  @click="moveArtist(index, -1)"
-                  icon
-                  small
-                  class="ma-2"
-                  :disabled="index === 0"
-                >
-                  <VIcon>mdi-menu-up</VIcon>
-                </VBtn>
-                <VBtn
-                  @click="moveArtist(index, 1)"
-                  icon
-                  small
-                  class="ma-2"
-                  :disabled="index === changeArtists.track_artists.length - 1"
-                >
-                  <VIcon>mdi-menu-down</VIcon>
-                </VBtn>
-                <VBtn @click="removeArtist(index)" icon small class="ma-2">
-                  <VIcon>mdi-close</VIcon>
-                </VBtn>
-              </VCol>
-              <VCol v-if="changeArtists.enabled">
-                <VCombobox
-                  :items="sortedArtists"
-                  item-text="name"
-                  item-value="id"
-                  :label="$tc('music.artists', 2)"
-                  return-object
-                  v-model="item.artist_id"
-                />
-                <VTextField :label="$t('common.name')" v-model="item.name" />
-                <VAutocomplete
-                  :items="roles"
-                  :label="$t('music.artist.role')"
-                  v-model="item.role"
-                />
-                <VDivider
-                  light
-                  v-if="index !== changeArtists.track_artists.length - 1"
-                />
-              </VCol>
-            </VRow>
-            <VBtn
-              @click="addArtist"
-              color="success"
-              class="ma-2"
-              v-if="changeArtists.enabled"
-            >
-              {{ $t("music.artist.add") }}
+          <VToolbarTitle>
+            {{
+              $tc("music.mass.edit-tracks", tracks.length, {
+                count: tracks.length,
+              })
+            }}
+          </VToolbarTitle>
+          <VSpacer></VSpacer>
+          <VToolbarItems>
+            <VBtn icon @click="saveTracks" :disabled="saving">
+              <VIcon>
+                {{ saving ? "mdi-refresh mdi-spin" : "mdi-content-save" }}
+              </VIcon>
             </VBtn>
+          </VToolbarItems>
+        </VToolbar>
+        <div style="overflow-y: auto; backface-visibility: hidden;">
+          <VContainer>
+            <Errors />
+            <VContainer
+              fluid
+              v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
+            >
+              <VRow dense>
+                <VCol cols="12">
+                  <VCheckbox v-model="showReviewComments">
+                    <template v-slot:label>
+                      <span class="black--text">
+                        {{
+                          $tc(
+                            "music.flag.show",
+                            tracks.filter((t) => t.review_comment !== null)
+                              .length
+                          )
+                        }}
+                      </span>
+                    </template>
+                  </VCheckbox>
+                </VCol>
+              </VRow>
+              <VRow v-if="showReviewComments">
+                <VCol cols="12">
+                  <VAlert
+                    :value="showReviewComments"
+                    type="warning"
+                    icon="mdi-flag"
+                  >
+                    <table class="review-comment-table">
+                      <tr
+                        v-for="t of tracks.filter(
+                          (tr) => tr.review_comment !== null
+                        )"
+                        :key="t.id"
+                      >
+                        <td class="text-right">
+                          <strong>{{ t.number }}</strong>
+                        </td>
+                        <td>
+                          <strong>{{ t.title }}</strong>
+                        </td>
+                        <td>{{ t.review_comment }}</td>
+                      </tr>
+                    </table>
+                  </VAlert>
+                </VCol>
+              </VRow>
+            </VContainer>
+            <VDivider
+              v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
+            />
+            <VContainer fluid>
+              <VRow dense>
+                <VCol cols="12" sm="6">
+                  <VCheckbox v-model="number.enabled">
+                    <template v-slot:label>
+                      <span class="black--text">
+                        {{ $t("music.mass.increase-track") }}
+                      </span>
+                    </template>
+                  </VCheckbox>
+                </VCol>
+                <VCol cols="12" sm="6">
+                  <VTextField
+                    v-model="number.amount"
+                    :label="$t('common.amount')"
+                    type="number"
+                    step="1"
+                    v-if="number.enabled"
+                    hide-details="true"
+                  />
+                </VCol>
+              </VRow>
+            </VContainer>
+            <VDivider />
+            <VContainer fluid>
+              <VRow dense>
+                <VCol cols="12" sm="6">
+                  <VCheckbox v-model="titleReplacement.enabled">
+                    <template v-slot:label>
+                      <span class="black--text">
+                        {{ $t("music.mass.title-search") }}
+                      </span>
+                    </template>
+                  </VCheckbox>
+                </VCol>
+                <VCol cols="12" sm="6">
+                  <VCheckbox
+                    v-model="titleReplacement.regex"
+                    :label="$t('music.mass.regex')"
+                    v-if="titleReplacement.enabled"
+                  />
+                </VCol>
+              </VRow>
+              <VRow v-if="titleReplacement.enabled">
+                <VCol cols="12" sm="6">
+                  <VTextField
+                    :label="$t('common.search')"
+                    v-model="titleReplacement.search"
+                  />
+                </VCol>
+                <VCol cols="12" sm="6">
+                  <VTextField
+                    :label="$t('common.replace')"
+                    v-model="titleReplacement.replace"
+                  />
+                </VCol>
+              </VRow>
+            </VContainer>
+            <VDivider />
+            <VContainer fluid>
+              <VRow dense>
+                <VCol cols="12" sm="6">
+                  <VCheckbox v-model="album.enabled">
+                    <template v-slot:label>
+                      <span class="black--text">
+                        {{ $t("music.mass.set-album") }}
+                      </span>
+                    </template>
+                  </VCheckbox>
+                </VCol>
+                <VCol cols="12" sm="6">
+                  <VAutocomplete
+                    :items="sortedAlbums"
+                    item-text="title"
+                    item-value="id"
+                    label="Album"
+                    hide-details="true"
+                    v-model="album.album"
+                    :rules="rules.album"
+                    v-if="album.enabled"
+                  />
+                </VCol>
+              </VRow>
+            </VContainer>
+            <VDivider />
+            <VContainer fluid>
+              <VRow dense>
+                <VCol cols="12" sm="6">
+                  <VCheckbox v-model="changeGenres.enabled">
+                    <template v-slot:label>
+                      <span class="black--text">
+                        {{ $t("music.mass.change-genres") }}
+                      </span>
+                    </template>
+                  </VCheckbox>
+                </VCol>
+                <VCol cols="12" sm="6">
+                  <VCheckbox
+                    v-model="changeGenres.replace"
+                    :label="$t('music.mass.replace-instead-genres')"
+                    v-if="changeGenres.enabled"
+                  />
+                </VCol>
+              </VRow>
+              <VRow v-if="changeGenres.enabled">
+                <VCol cols="12" sm="6">
+                  <VCombobox
+                    :items="sortedGenres"
+                    cache-items
+                    chips
+                    deletable-chips
+                    item-text="name"
+                    item-value="id"
+                    :label="$t('music.genre-s')"
+                    multiple
+                    return-object
+                    v-model="changeGenres.genres"
+                    :rules="rules.genre"
+                    validate-on-blur
+                  />
+                </VCol>
+              </VRow>
+            </VContainer>
+            <VDivider />
+            <VContainer fluid>
+              <VRow dense>
+                <VCol cols="12" sm="6">
+                  <VCheckbox v-model="changeArtists.enabled">
+                    <template v-slot:label>
+                      <span class="black--text">
+                        {{ $t("music.mass.change-artists") }}
+                      </span>
+                    </template>
+                  </VCheckbox>
+                </VCol>
+                <VCol cols="12" sm="6">
+                  <VCheckbox
+                    v-model="changeArtists.replace"
+                    :label="$t('music.mass.replace-instead-artists')"
+                    v-if="changeArtists.enabled"
+                  />
+                </VCol>
+              </VRow>
+              <VRow
+                :key="index"
+                v-for="(item, index) of changeArtists.track_artists"
+                no-gutters
+              >
+                <VCol class="flex-column no-grow" v-if="changeArtists.enabled">
+                  <VBtn
+                    @click="moveArtist(index, -1)"
+                    icon
+                    small
+                    class="ma-2"
+                    :disabled="index === 0"
+                  >
+                    <VIcon>mdi-menu-up</VIcon>
+                  </VBtn>
+                  <VBtn
+                    @click="moveArtist(index, 1)"
+                    icon
+                    small
+                    class="ma-2"
+                    :disabled="index === changeArtists.track_artists.length - 1"
+                  >
+                    <VIcon>mdi-menu-down</VIcon>
+                  </VBtn>
+                  <VBtn @click="removeArtist(index)" icon small class="ma-2">
+                    <VIcon>mdi-close</VIcon>
+                  </VBtn>
+                </VCol>
+                <VCol v-if="changeArtists.enabled">
+                  <VCombobox
+                    :items="sortedArtists"
+                    item-text="name"
+                    item-value="id"
+                    :label="$tc('music.artists', 2)"
+                    :rules="rules.artist"
+                    return-object
+                    v-model="item.artist_id"
+                  />
+                  <VTextField :label="$t('common.name')" v-model="item.name" />
+                  <VAutocomplete
+                    :items="roles"
+                    :label="$t('music.artist.role')"
+                    v-model="item.role"
+                  />
+                  <VDivider
+                    light
+                    v-if="index !== changeArtists.track_artists.length - 1"
+                  />
+                </VCol>
+              </VRow>
+              <VBtn
+                @click="addArtist"
+                color="success"
+                class="ma-2"
+                v-if="changeArtists.enabled"
+              >
+                {{ $t("music.artist.add") }}
+              </VBtn>
+            </VContainer>
+            <VDivider
+              v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
+            />
+            <VContainer
+              fluid
+              v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
+            >
+              <VRow dense>
+                <VCol cols="12" sm="6">
+                  <VCheckbox v-model="clearReviewComments">
+                    <template v-slot:label>
+                      <span class="black--text">
+                        {{
+                          $tc(
+                            "music.flag.clear",
+                            tracks.filter((t) => t.review_comment !== null)
+                              .length
+                          )
+                        }}
+                      </span>
+                    </template>
+                  </VCheckbox>
+                </VCol>
+              </VRow>
+            </VContainer>
           </VContainer>
-          <VDivider
-            v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
-          />
-          <VContainer
-            fluid
-            v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
-          >
-            <VRow dense>
-              <VCol cols="12" sm="6">
-                <VCheckbox v-model="clearReviewComments">
-                  <template v-slot:label>
-                    <span class="black--text">
-                      {{
-                        $tc(
-                          "music.flag.clear",
-                          tracks.filter((t) => t.review_comment !== null).length
-                        )
-                      }}
-                    </span>
-                  </template>
-                </VCheckbox>
-              </VCol>
-            </VRow>
-          </VContainer>
-        </VContainer>
-      </div>
+        </div>
+      </VForm>
     </VCard>
   </VDialog>
 </template>
@@ -387,6 +393,7 @@ export default {
       clearReviewComments: false,
       showReviewComments: false,
       saving: false,
+      isValid: true,
     };
   },
   computed: {
@@ -405,6 +412,8 @@ export default {
     rules: function () {
       const rules = {
         genre: [],
+        artist: [],
+        album: [],
       };
 
       const genreValidation = (v) => {
@@ -429,6 +438,18 @@ export default {
         rules.genre.push(genreValidation);
       }
 
+      if (this.changeArtists.enabled) {
+        const artistValidation = (v) =>
+          !!v || this.$t("errors.artists.artist-blank");
+        rules.artist.push(artistValidation);
+      }
+
+      if (this.album.enabled) {
+        const albumValidation = (v) =>
+          !!v || this.$t("errors.albums.album-blank");
+        rules.album.push(albumValidation);
+      }
+
       return rules;
     },
   },
@@ -439,6 +460,9 @@ export default {
       createGenre: "genres/create",
     }),
     saveTracks() {
+      this.$refs.form.validate();
+      if (!this.isValid) return false;
+
       this.saving = true;
       const transformedArtists = [];
       const transformedGenres = [];

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -91,6 +91,9 @@
 			"ffmepg-blank": "Please fill in the FFmpeg parameters.",
 			"result-blank": "Please fill in a resulting codec."
 		},
+		"cover_filename": {
+			"filename-blank": "Please fill in a cover filename."
+		},
 		"current_password": "Current Password",
 		"error": "Error",
 		"exception": "Exception",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,6 +63,7 @@
 	"errors": {
 		"album_artists": "Album artists",
 		"albums": {
+			"album-blank": "Please select an album.",
 			"title-blank": "Please fill in an album title."
 		},
 		"aa": {
@@ -76,6 +77,7 @@
 		},
 		"artist": "Artist",
 		"artists": {
+			"artist-blank": "Please select an artist.",
 			"name-blank": "Please fill in artist name."
 		},
 		"base": "Base",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -147,11 +147,13 @@
 		"traces": "Traces",
 		"unauthorized": "Unauthorized",
 		"user": {
+			"current-password-blank": "Please fill in your current password.",
 			"current-password-incorrect": "Your current password was incorrect.",
 			"name": "Username",
 			"name-blank": "Please fill in a username.",
 			"password-blank": "Please fill in a password.",
 			"password-confirmation": "Confirmation doensn't match password.",
+			"password-confirmation-blank": "Please confirmation your password.",
 			"permission-blank": "Please give the user a permission.",
 			"wrong-credentials": "Username and password don't match."
 		}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -98,7 +98,8 @@
 		"ffmpeg": "FFmpeg parameters",
 		"genre": {
 			"name-blank": "Please fill in a genre name.",
-			"name-taken": "A genre with this name already exists."
+			"name-taken": "A genre with this name already exists.",
+			"name-taken-obj": "A genre called {obj} already exists."
 		},
 		"image": {
 			"mime-blank": "Please fill in a MIMEtype.",
@@ -142,6 +143,7 @@
 		"track": "Track",
 		"tracks": {
 			"number-blank": "Please provide a track number",
+			"number-whole": "Please provide a whole number",
 			"title-blank": "Please provide a track title."
 		},
 		"traces": "Traces",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -63,6 +63,7 @@
 	"errors": {
 		"album_artists": "Album artiesten",
 		"albums": {
+			"album-blank": "Selecteer een album.",
 			"title-blank": "Vul aub een albumtitel in."
 		},
 		"aa": {
@@ -76,6 +77,7 @@
 		},
 		"artist": "Artiest",
 		"artists": {
+			"artist-blank": "Selecteer een artiest.",
 			"name-blank": "Vul een artiestennaam in."
 		},
 		"base": "Base",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -98,7 +98,8 @@
 		"ffmpeg": "FFmpeg parameters",
 		"genre": {
 			"name-blank": "Vul een naam voor het genre in.",
-			"name-taken": "Een genre met deze naam bestaat reeds."
+			"name-taken": "Een genre met deze naam bestaat reeds.",
+			"name-taken-obj": "Er bestaat al een genre met naam {obj}."
 		},
 		"image": {
 			"mime-blank": "Vul een MIMEtype in.",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -147,11 +147,13 @@
 		"traces": "Sporen",
 		"unauthorized": "Onbevoegd",
 		"user": {
+			"current-password-blank": "Vul je huidige wachtwoord in.",
 			"current-password-incorrect": "Je huidige wachtwoord was fout.",
 			"name": "Gebruikersnaam",
 			"name-blank": "Vul een gebruikersnaam in.",
 			"password-blank": "Vul een wachtwoord in.",
 			"password-confirmation": "Bevestiging komt niet overeen met wachtwoord.",
+			"password-confirmation-blank": "Bevestig je wachtwoord.",
 			"permission-blank": "Selecteer een permissie voor de gebruiker.",
 			"wrong-credentials": "De gebruikersnaam en het wachtwoord komen niet overeen."
 		}

--- a/src/views/albums/EditAlbum.vue
+++ b/src/views/albums/EditAlbum.vue
@@ -18,7 +18,6 @@
             v-model="newAlbum.title"
             :rules="[(v) => !!v || $t('errors.albums.title-blank')]"
             required
-            aria-required="true"
           />
           <VDialog
             ref="dialogOriginal"

--- a/src/views/albums/EditAlbum.vue
+++ b/src/views/albums/EditAlbum.vue
@@ -12,8 +12,14 @@
         >
           {{ album.review_comment }}
         </VAlert>
-        <VForm @submit.prevent="submit">
-          <VTextField :label="$t('music.title')" v-model="newAlbum.title" />
+        <VForm v-model="isValid" @submit.prevent="submit">
+          <VTextField
+            :label="$t('music.title')"
+            v-model="newAlbum.title"
+            :rules="[(v) => !!v || $t('errors.albums.title-blank')]"
+            required
+            aria-required="true"
+          />
           <VDialog
             ref="dialogOriginal"
             v-model="originalModal"
@@ -184,7 +190,12 @@
             :label="$tc('music.flag.clear', 1)"
           />
           <VRow justify="center">
-            <VBtn color="primary" class="ma-2" type="submit">
+            <VBtn
+              :disabled="!isValid"
+              color="primary"
+              class="ma-2"
+              type="submit"
+            >
               {{ $t("music.album.update") }}
             </VBtn>
             <VSpacer />
@@ -210,6 +221,7 @@ export default {
   components: { FilePicker },
   data() {
     return {
+      isValid: true,
       originalModal: false,
       editionModal: false,
       newAlbum: {

--- a/src/views/albums/NewAlbum.vue
+++ b/src/views/albums/NewAlbum.vue
@@ -9,7 +9,6 @@
             v-model="newAlbum.title"
             :rules="[(v) => !!v || $t('errors.albums.title-blank')]"
             required
-            aria-required="true"
           />
           <VDialog
             ref="dialogOriginal"

--- a/src/views/albums/NewAlbum.vue
+++ b/src/views/albums/NewAlbum.vue
@@ -3,8 +3,14 @@
     <vue-headful :title="$t('music.album.new') + ' | Accentor'" />
     <VRow no-gutters align="center" justify="center">
       <VCol lg="6" sm="8" cols="12">
-        <VForm @submit.prevent="submit">
-          <VTextField :label="$t('music.title')" v-model="newAlbum.title" />
+        <VForm v-model="isValid" @submit.prevent="submit">
+          <VTextField
+            :label="$t('music.title')"
+            v-model="newAlbum.title"
+            :rules="[(v) => !!v || $t('errors.albums.title-blank')]"
+            required
+            aria-required="true"
+          />
           <VDialog
             ref="dialogOriginal"
             v-model="originalModal"
@@ -169,7 +175,12 @@
             </VCol>
           </VRow>
           <VRow justify="center">
-            <VBtn color="primary" class="ma-2" type="submit">
+            <VBtn
+              :disabled="!isValid"
+              color="primary"
+              class="ma-2"
+              type="submit"
+            >
               {{ $t("music.album.create") }}
             </VBtn>
             <VSpacer />
@@ -219,6 +230,7 @@ export default {
         ],
       },
       editionInformation: false,
+      isValid: true,
     };
   },
   computed: {

--- a/src/views/artists/EditArtist.vue
+++ b/src/views/artists/EditArtist.vue
@@ -18,7 +18,6 @@
             v-model="newArtist.name"
             :rules="[(v) => !!v || $t('errors.artists.name-blank')]"
             required
-            aria-required="true"
           />
           <FilePicker v-model="newArtist.image" />
           <VCheckbox

--- a/src/views/artists/EditArtist.vue
+++ b/src/views/artists/EditArtist.vue
@@ -12,15 +12,21 @@
         >
           {{ artist.review_comment }}
         </VAlert>
-        <VForm @submit.prevent="submit">
-          <VTextField :label="$t('common.name')" v-model="newArtist.name" />
+        <VForm v-model="isValid" @submit.prevent="submit">
+          <VTextField
+            :label="$t('common.name')"
+            v-model="newArtist.name"
+            :rules="[(v) => !!v || $t('errors.artists.name-blank')]"
+            required
+            aria-required="true"
+          />
           <FilePicker v-model="newArtist.image" />
           <VCheckbox
             v-if="artist.review_comment !== null"
             v-model="clear_review_comment"
             :label="$tc('music.flag.clear', 1)"
           />
-          <VBtn color="primary" class="ma-2" type="submit">
+          <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">
             {{ $t("music.artist.update") }}
           </VBtn>
         </VForm>
@@ -44,6 +50,7 @@ export default {
         review_comment: null,
       },
       clear_review_comment: true,
+      isValid: true,
     };
   },
   created() {

--- a/src/views/artists/NewArtist.vue
+++ b/src/views/artists/NewArtist.vue
@@ -9,7 +9,6 @@
             v-model="newArtist.name"
             :rules="[(v) => !!v || $t('errors.artists.name-blank')]"
             required
-            aria-required="true"
           />
           <FilePicker v-model="newArtist.image" />
           <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">

--- a/src/views/artists/NewArtist.vue
+++ b/src/views/artists/NewArtist.vue
@@ -3,10 +3,16 @@
     <vue-headful :title="$t('music.artist.new') + ' | Accentor'" />
     <VRow no-gutters align="center" justify="center">
       <VCol md="4" sm="8" cols="12">
-        <VForm @submit.prevent="submit">
-          <VTextField :label="$t('common.name')" v-model="newArtist.name" />
+        <VForm v-model="isValid" @submit.prevent="submit">
+          <VTextField
+            :label="$t('common.name')"
+            v-model="newArtist.name"
+            :rules="[(v) => !!v || $t('errors.artists.name-blank')]"
+            required
+            aria-required="true"
+          />
           <FilePicker v-model="newArtist.image" />
-          <VBtn color="primary" class="ma-2" type="submit">
+          <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">
             {{ $t("music.artist.add") }}
           </VBtn>
         </VForm>
@@ -28,6 +34,7 @@ export default {
         name: "",
         image: null,
       },
+      isValid: true,
     };
   },
   methods: {

--- a/src/views/genres/EditGenre.vue
+++ b/src/views/genres/EditGenre.vue
@@ -5,9 +5,15 @@
     />
     <VRow no-gutters align="center" justify="center">
       <VCol md="4" sm="8" cols="12">
-        <VForm @submit.prevent="submit">
-          <VTextField genre="Name" v-model="newGenre.name" />
-          <VBtn color="primary" class="ma-2" type="submit">
+        <VForm v-model="isValid" @submit.prevent="submit">
+          <VTextField
+            :label="$t('common.name')"
+            v-model="newGenre.name"
+            :rules="[(v) => !!v || $t('errors.genre.name-blank')]"
+            required
+            aria-required="true"
+          />
+          <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">
             {{ $t("music.genre.update") }}
           </VBtn>
         </VForm>
@@ -26,6 +32,7 @@ export default {
       newGenre: {
         name: "",
       },
+      isValid: true,
     };
   },
   created() {

--- a/src/views/genres/EditGenre.vue
+++ b/src/views/genres/EditGenre.vue
@@ -11,7 +11,6 @@
             v-model="newGenre.name"
             :rules="[(v) => !!v || $t('errors.genre.name-blank')]"
             required
-            aria-required="true"
           />
           <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">
             {{ $t("music.genre.update") }}

--- a/src/views/labels/EditLabel.vue
+++ b/src/views/labels/EditLabel.vue
@@ -11,7 +11,6 @@
             v-model="newLabel.name"
             :rules="[(v) => !!v || $t('errors.label.name-blank')]"
             required
-            aria-required="true"
           />
           <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">
             {{ $t("music.label.update") }}

--- a/src/views/labels/EditLabel.vue
+++ b/src/views/labels/EditLabel.vue
@@ -5,9 +5,15 @@
     />
     <VRow no-gutters align="center" justify="center">
       <VCol md="4" sm="8" cols="12">
-        <VForm @submit.prevent="submit">
-          <VTextField :label="$t('common.name')" v-model="newLabel.name" />
-          <VBtn color="primary" class="ma-2" type="submit">
+        <VForm v-model="isValid" @submit.prevent="submit">
+          <VTextField
+            :label="$t('common.name')"
+            v-model="newLabel.name"
+            :rules="[(v) => !!v || $t('errors.label.name-blank')]"
+            required
+            aria-required="true"
+          />
+          <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">
             {{ $t("music.label.update") }}
           </VBtn>
         </VForm>
@@ -26,6 +32,7 @@ export default {
       newLabel: {
         name: "",
       },
+      isValid: true,
     };
   },
   created() {

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -45,7 +45,6 @@
             :label="$t('users.confirm-password')"
             type="password"
             autocomplete="new-password"
-            required
             :rules="rules.confirmation"
             v-model="newUser.password_confirmation"
           />

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -15,11 +15,12 @@
         </VForm>
       </VCol>
       <VCol lg="4" md="6" sm="8" cols="12" class="px-3">
-        <VForm @submit.prevent="submitPassword">
+        <VForm v-model="isValid" @submit.prevent="submitPassword">
           <VTextField
             :label="$t('common.name')"
             v-model="newUser.name"
             autocomplete="username"
+            :rules="[(v) => !!v || $t('errors.user.name-blank')]"
           />
           <VTextField
             :label="$t('users.current-password')"
@@ -39,7 +40,7 @@
             autocomplete="new-password"
             v-model="newUser.password_confirmation"
           />
-          <VBtn color="primary" class="ma-2" type="submit">
+          <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">
             {{ $t("common.change-settings") }}
           </VBtn>
         </VForm>
@@ -68,6 +69,7 @@ export default {
         password: "",
         password_confirmation: "",
       },
+      isValid: true,
       newLocale: "",
       langs: [
         { value: "en", text: "English" },

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -15,11 +15,16 @@
         </VForm>
       </VCol>
       <VCol lg="4" md="6" sm="8" cols="12" class="px-3">
-        <VForm v-model="isValid" @submit.prevent="submitPassword">
+        <VForm
+          v-model="isValid"
+          ref="userForm"
+          @submit.prevent="submitPassword"
+        >
           <VTextField
             :label="$t('common.name')"
             v-model="newUser.name"
             autocomplete="username"
+            required
             :rules="[(v) => !!v || $t('errors.user.name-blank')]"
           />
           <VTextField
@@ -27,20 +32,24 @@
             type="password"
             autocomplete="current-password"
             v-model="newUser.current_password"
+            :rules="rules.current"
           />
           <VTextField
             :label="$t('users.password')"
             type="password"
             autocomplete="new-password"
             v-model="newUser.password"
+            :rules="rules.password"
           />
           <VTextField
             :label="$t('users.confirm-password')"
             type="password"
             autocomplete="new-password"
+            required
+            :rules="rules.confirmation"
             v-model="newUser.password_confirmation"
           />
-          <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">
+          <VBtn color="primary" class="ma-2" type="submit">
             {{ $t("common.change-settings") }}
           </VBtn>
         </VForm>
@@ -94,10 +103,37 @@ export default {
     ...mapGetters("auth", { user: "currentUser" }),
     ...mapGetters("auth", ["authTokens"]),
     ...mapState("userSettings", ["locale"]),
+    rules() {
+      const rules = {
+        confirmation: [],
+        current: [],
+        password: [],
+      };
+      if (this.newUser.password) {
+        const confirmationBlank = (v) =>
+          !!v || this.$t("errors.user.password-confirmation-blank");
+        rules.confirmation.push(confirmationBlank);
+
+        const confirmationMatch = (v) =>
+          (!!v && v) === this.newUser.password ||
+          this.$t("errors.user.password-confirmation");
+        rules.confirmation.push(confirmationMatch);
+
+        const currentBlank = (v) =>
+          !!v || this.$t("errors.user.current-password-blank");
+        rules.current.push(currentBlank);
+      }
+
+      if (this.newUser.current_password || this.newUser.password_confirmation) {
+        const passwordBlank = (v) =>
+          !!v || this.$t("errors.user.password-blank");
+        rules.password.push(passwordBlank);
+      }
+      return rules;
+    },
   },
   methods: {
     ...mapActions("users", ["update"]),
-
     ...mapMutations("userSettings", ["setLocale"]),
     fillValues() {
       if (this.user) this.newUser.name = this.user.name;
@@ -109,13 +145,16 @@ export default {
       });
     },
     submitPassword() {
-      this.update({ id: this.user.id, newUser: this.newUser }).then(
-        (succeeded) => {
-          if (succeeded) {
-            this.$router.push(this.$route.query.redirect || { name: "home" });
+      this.$refs.userForm.validate();
+      if (this.isValid) {
+        this.update({ id: this.user.id, newUser: this.newUser }).then(
+          (succeeded) => {
+            if (succeeded) {
+              this.$router.push(this.$route.query.redirect || { name: "home" });
+            }
           }
-        }
-      );
+        );
+      }
     },
   },
 };

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -221,7 +221,7 @@ export default {
             );
             if (double) {
               valid = this.$t("errors.genre.name-taken-obj", { obj: newGenre });
-            } else if (newGenre.length) {
+            } else if (!newGenre.trim().length) {
               valid = this.$t("errors.genre.name-blank");
             }
           }

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -43,6 +43,8 @@
             :label="$t('music.genre-s')"
             multiple
             return-object
+            :rules="rules.genre"
+            validate-on-blur
             v-model="newTrack.genre_ids"
           />
           <h4 class="text-subtitle-1">{{ $tc("music.artists", 2) }}</h4>
@@ -205,8 +207,28 @@ export default {
           (v) => !!v || this.$t("errors.tracks.number-blank"),
           (v) => Number(v) % 1 === 0 || this.$t("errors.tracks.number-whole"),
         ],
+        genre: [],
       };
 
+      const genreValidation = (v) => {
+        let valid = true;
+        v.forEach((newGenre) => {
+          if (typeof newGenre !== "object") {
+            const double = this.sortedGenres.some(
+              (g) =>
+                g.name === newGenre ||
+                g.normalized_name === newGenre.toLowerCase()
+            );
+            if (double) {
+              valid = this.$t("errors.genre.name-taken-obj", { obj: newGenre });
+            } else if (newGenre.length) {
+              valid = this.$t("errors.genre.name-blank");
+            }
+          }
+        });
+        return valid; // We only return the last error, since we can only display one
+      };
+      rules.genre.push(genreValidation);
 
       return rules;
     },

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -12,13 +12,20 @@
         >
           {{ track.review_comment }}
         </VAlert>
-        <VForm @submit.prevent="submit">
+        <VForm v-model="isValid" @submit.prevent="submit">
           <VTextField
             type="number"
             :label="$t('music.track.number')"
+            :rules="rules.number"
+            min="0"
+            step="1"
             v-model="newTrack.number"
           />
-          <VTextField :label="$t('music.title')" v-model="newTrack.title" />
+          <VTextField
+            :label="$t('music.title')"
+            :rules="[(v) => !!v || $t('errors.tracks.title-blank')]"
+            v-model="newTrack.title"
+          />
           <VAutocomplete
             :items="sortedAlbums"
             item-text="title"
@@ -91,7 +98,12 @@
             :label="$tc('music.flag.clear', 1)"
           />
           <VRow>
-            <VBtn color="primary" class="ma-2" type="submit">
+            <VBtn
+              :disabled="!isValid"
+              color="primary"
+              class="ma-2"
+              type="submit"
+            >
               {{ $t("music.track.update") }}
             </VBtn>
             <VSpacer />
@@ -151,6 +163,7 @@ export default {
         },
       ],
       clear_review_comment: true,
+      isValid: true,
     };
   },
   created() {
@@ -185,6 +198,17 @@ export default {
         this.$store.state.tracks &&
         this.$store.state.tracks.tracks[this.$route.params.id]
       );
+    },
+    rules: function () {
+      const rules = {
+        number: [
+          (v) => !!v || this.$t("errors.tracks.number-blank"),
+          (v) => Number(v) % 1 === 0 || this.$t("errors.tracks.number-whole"),
+        ],
+      };
+
+
+      return rules;
     },
   },
   methods: {

--- a/src/views/users/EditUser.vue
+++ b/src/views/users/EditUser.vue
@@ -5,23 +5,31 @@
     />
     <VRow no-gutters align="center" justify="center">
       <VCol md="4" sm="8" cols="12">
-        <VForm @submit.prevent="submit">
-          <VTextField :label="$t('common.name')" v-model="newUser.name" />
+        <VForm v-model="isValid" ref="userForm" @submit.prevent="submit">
+          <VTextField
+            :label="$t('common.name')"
+            v-model="newUser.name"
+            required
+            :rules="[(v) => !!v || $t('errors.user.name-blank')]"
+          />
           <VTextField
             v-if="user === currentUser"
             :label="$t('users.current-password')"
             type="password"
             v-model="newUser.current_password"
+            :rules="rules.current"
           />
           <VTextField
             :label="$t('users.password')"
             type="password"
             v-model="newUser.password"
+            :rules="rules.password"
           />
           <VTextField
             :label="$t('users.confirm-password')"
             type="password"
             v-model="newUser.password_confirmation"
+            :rules="rules.confirmation"
           />
           <VSelect
             :items="permissionOptions"
@@ -56,6 +64,7 @@ export default {
         { text: this.$t("users.permission.moderator"), value: "moderator" },
         { text: this.$t("users.permission.user"), value: "user" },
       ],
+      isValid: true,
     };
   },
   created() {
@@ -78,6 +87,34 @@ export default {
     user: function () {
       return this.users[this.$route.params.id];
     },
+    rules() {
+      const rules = {
+        confirmation: [],
+        current: [],
+        password: [],
+      };
+      if (this.newUser.password) {
+        const confirmationBlank = (v) =>
+          !!v || this.$t("errors.user.password-confirmation-blank");
+        rules.confirmation.push(confirmationBlank);
+
+        const confirmationMatch = (v) =>
+          (!!v && v) === this.newUser.password ||
+          this.$t("errors.user.password-confirmation");
+        rules.confirmation.push(confirmationMatch);
+
+        const currentBlank = (v) =>
+          !!v || this.$t("errors.user.current-password-blank");
+        rules.current.push(currentBlank);
+      }
+
+      if (this.newUser.current_password || this.newUser.password_confirmation) {
+        const passwordBlank = (v) =>
+          !!v || this.$t("errors.user.password-blank");
+        rules.password.push(passwordBlank);
+      }
+      return rules;
+    },
   },
   methods: {
     ...mapActions("users", ["update"]),
@@ -86,13 +123,18 @@ export default {
       this.newUser.permission = this.user.permission;
     },
     submit() {
-      this.update({ id: this.user.id, newUser: this.newUser }).then(
-        (succeeded) => {
-          if (succeeded) {
-            this.$router.push(this.$route.query.redirect || { name: "users" });
+      this.$refs.userForm.validate();
+      if (this.isValid) {
+        this.update({ id: this.user.id, newUser: this.newUser }).then(
+          (succeeded) => {
+            if (succeeded) {
+              this.$router.push(
+                this.$route.query.redirect || { name: "users" }
+              );
+            }
           }
-        }
-      );
+        );
+      }
     },
   },
 };

--- a/src/views/users/NewUser.vue
+++ b/src/views/users/NewUser.vue
@@ -3,24 +3,35 @@
     <vue-headful :title="$t('users.new') + ' | Accentor'" />
     <VRow no-gutters align="center" justify="center">
       <VCol md="4" sm="8" cols="12">
-        <VForm @submit.prevent="submit">
-          <VTextField :label="$t('common.name')" v-model="newUser.name" />
+        <VForm v-model="isValid" @submit.prevent="submit">
+          <VTextField
+            :label="$t('common.name')"
+            v-model="newUser.name"
+            required
+            :rules="[(v) => !!v || $t('errors.user.name-blank')]"
+          />
           <VTextField
             :label="$t('users.password')"
             type="password"
             v-model="newUser.password"
+            required
+            :rules="[(v) => !!v || $t('errors.user.password-blank')]"
           />
           <VTextField
             :label="$t('users.confirm-password')"
             type="password"
             v-model="newUser.password_confirmation"
+            required
+            :rules="rules.confirmation"
           />
           <VSelect
             :items="permissionOptions"
             :label="$t('users.permissions')"
+            required
             v-model="newUser.permission"
+            :rules="[(v) => !!v || $t('errors.user.permission-blank')]"
           />
-          <VBtn color="primary" class="ma-2" type="submit">
+          <VBtn :disabled="!isValid" color="primary" class="ma-2" type="submit">
             {{ $t("users.create") }}
           </VBtn>
         </VForm>
@@ -48,6 +59,20 @@ export default {
         { text: this.$t("users.permission.user"), value: "user" },
       ],
     };
+  },
+  computed: {
+    rules() {
+      const rules = {
+        confirmation: [
+          (v) => !!v || this.$t("errors.user.password-confirmation-blank"),
+          (v) =>
+            (!!v && v) === this.newUser.password ||
+            this.$t("errors.user.password-confirmation"),
+        ],
+      };
+
+      return rules;
+    },
   },
   methods: {
     ...mapActions("users", ["create"]),


### PR DESCRIPTION
fix #100 

depends on #182

Uses [vuetify's built-in validation](https://vuetifyjs.com/en/components/forms/)
* If a field only required one rule, I've added it directly as an attribute
* If a field required multiple rules or more complex, I've added it to a computed property (one per form). 
* Lazy validation is used when validating too eagerly would be annoying (fe. password confirmation) or if the form is not on a specific page (Forms on library pages).