### PR TITLE
Move moderator's actions into expand button

### DIFF
--- a/src/Main.vue
+++ b/src/Main.vue
@@ -8,4 +8,8 @@
 a {
   text-decoration: none;
 }
+
+.flex-basis-auto {
+  flex-basis: auto;
+}
 </style>

--- a/src/Main.vue
+++ b/src/Main.vue
@@ -8,8 +8,4 @@
 a {
   text-decoration: none;
 }
-
-.flex-basis-auto {
-  flex-basis: auto;
-}
 </style>

--- a/src/components/EditReviewComment.vue
+++ b/src/components/EditReviewComment.vue
@@ -1,7 +1,7 @@
 <template>
   <VBtn
     color="flag"
-    class="ma-2"
+    class="ma-1"
     text
     icon
     small

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -138,19 +138,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.flip-icon-leave {
-  transform: none;
-}
-
-.flip-icon-leave-active {
-  transition-duration: 750ms;
-  transition-property: transform;
-  transition-timing-function: ease-in;
-}
-
-.flip-icon-leave-to {
-  transform: rotate(0.5turn);
-}
-</style>

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -37,7 +37,7 @@
       <span>{{ $t("music.track.empty") }}</span>
     </VTooltip>
     <EditReviewComment :item="track" :update="flag" />
-    <VMenu>
+    <VMenu v-if="isModerator">
       <template v-slot:activator="{ on, attrs }">
         <VBtn class="ma-1" small icon v-bind="attrs" v-on="on">
           <VIcon>mdi-dots-vertical</VIcon>

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -97,11 +97,6 @@ export default {
   props: {
     track: { type: Object, required: true },
   },
-  data() {
-    return {
-      expanded: false,
-    };
-  },
   computed: {
     ...mapGetters("auth", ["isModerator"]),
     ...mapState("tracks", ["startLoading"]),

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -36,64 +36,54 @@
       </template>
       <span>{{ $t("music.track.empty") }}</span>
     </VTooltip>
-    <EditReviewComment :item="track" :update="flag" v-if="!isModerator" />
-    <VBtn
-      class="ma-1"
-      color="edit"
-      small
-      icon
-      @click.stop="expanded = !expanded"
-    >
-      <transition name="flip-icon" mode="out-in">
-        <VIcon v-if="expanded" key="left">mdi-arrow-expand-left</VIcon>
-        <VIcon v-else key="right">mdi-arrow-expand-right</VIcon>
-      </transition>
-    </VBtn>
-    <VSlideXReverseTransition>
-      <span v-show="expanded">
-        <EditReviewComment :item="track" :update="flag" />
+    <EditReviewComment :item="track" :update="flag"/>
+    <VMenu>
+      <template v-slot:activator="{ on, attrs }">
+        <VBtn class="ma-1" small icon v-bind="attrs" v-on="on">
+          <VIcon>mdi-dots-vertical</VIcon>
+        </VBtn>
+      </template>
+      <VList>
         <VTooltip bottom :disabled="!waitingForReload">
           <template v-slot:activator="{ on }">
-            <span v-on="on">
-              <VBtn
-                :to="{
-                  name: 'edit-track',
-                  params: { id: track.id },
-                  query: { redirect: $route.fullPath },
-                }"
-                :disabled="waitingForReload"
-                color="edit"
-                class="ma-1"
-                text
-                icon
-                small
-              >
-                <VIcon>mdi-pencil</VIcon>
-              </VBtn>
-            </span>
+            <VListItem
+              :to="{
+                name: 'edit-track',
+                params: { id: track.id },
+                query: { redirect: $route.fullPath },
+              }"
+              :disabled="waitingForReload"
+              v-on="on"
+            >
+              <VListItemIcon>
+                <VIcon color="edit">mdi-pencil</VIcon>
+              </VListItemIcon>
+              <VListItemContent>
+                <VListItemTitle>Edit Track</VListItemTitle>
+              </VListItemContent>
+            </VListItem>
           </template>
           <span>{{ $t("common.disabled-while-loading") }}</span>
         </VTooltip>
         <VTooltip bottom :disabled="!waitingForReload">
           <template v-slot:activator="{ on }">
-            <span v-on="on">
-              <VBtn
-                @click.stop.prevent="deleteTrack"
-                :disabled="waitingForReload"
-                color="danger"
-                class="ma-1"
-                text
-                icon
-                small
-              >
-                <VIcon>mdi-delete</VIcon>
-              </VBtn>
-            </span>
+            <VListItem
+              @click.stop.prevent="deleteTrack"
+              :disabled="waitingForReload"
+              v-on="on"
+            >
+              <VListItemIcon>
+                <VIcon color="danger">mdi-delete</VIcon>
+              </VListItemIcon>
+              <VListItemContent>
+                <VListItemTitle>Delete Track</VListItemTitle>
+              </VListItemContent>
+            </VListItem>
           </template>
           <span>{{ $t("common.disabled-while-loading") }}</span>
         </VTooltip>
-      </span>
-    </VSlideXReverseTransition>
+      </VList>
+    </VMenu>
   </span>
 </template>
 

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -59,7 +59,7 @@
                 <VIcon color="edit">mdi-pencil</VIcon>
               </VListItemIcon>
               <VListItemContent>
-                <VListItemTitle>Edit Track</VListItemTitle>
+                <VListItemTitle>{{ $t("music.track.edit") }}</VListItemTitle>
               </VListItemContent>
             </VListItem>
           </template>
@@ -76,7 +76,7 @@
                 <VIcon color="danger">mdi-delete</VIcon>
               </VListItemIcon>
               <VListItemContent>
-                <VListItemTitle>Delete Track</VListItemTitle>
+                <VListItemTitle>{{ $t("music.track.delete") }}</VListItemTitle>
               </VListItemContent>
             </VListItem>
           </template>

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -44,8 +44,10 @@
       icon
       @click.stop="expanded = !expanded"
     >
-      <VIcon v-if="expanded">mdi-arrow-expand-left</VIcon>
-      <VIcon v-else>mdi-arrow-expand-right</VIcon>
+      <transition name="flip-icon" mode="out-in">
+        <VIcon v-if="expanded" key="left">mdi-arrow-expand-left</VIcon>
+        <VIcon v-else key="right">mdi-arrow-expand-right</VIcon>
+      </transition>
     </VBtn>
     <VSlideXReverseTransition>
       <span v-show="expanded">
@@ -138,3 +140,19 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.flip-icon-leave {
+  transform: none;
+}
+
+.flip-icon-leave-active {
+  transition-duration: 750ms;
+  transition-property: transform;
+  transition-timing-function: ease-in;
+}
+
+.flip-icon-leave-to {
+  transform: rotate(0.5turn);
+}
+</style>

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -43,7 +43,7 @@
           <VIcon>mdi-dots-vertical</VIcon>
         </VBtn>
       </template>
-      <VList>
+      <VList dense>
         <VTooltip bottom :disabled="!waitingForReload">
           <template v-slot:activator="{ on }">
             <VListItem

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -52,33 +52,46 @@
     <VSlideXReverseTransition>
       <span v-show="expanded">
         <EditReviewComment :item="track" :update="flag" />
-        <VBtn
-          :to="{
-            name: 'edit-track',
-            params: { id: track.id },
-            query: { redirect: $route.fullPath },
-          }"
-          :disabled="waitingForReload"
-          color="edit"
-          class="ma-1 flex-grow-0 flex-basis-auto"
-          text
-          icon
-          small
-        >
-          <VIcon>mdi-pencil</VIcon>
-        </VBtn>
-
-        <VBtn
-          @click.stop.prevent="deleteTrack"
-          :disabled="waitingForReload"
-          color="danger"
-          class="ma-1 flex-grow-0 flex-basis-auto"
-          text
-          icon
-          small
-        >
-          <VIcon>mdi-delete</VIcon>
-        </VBtn>
+        <VTooltip bottom :disabled="!waitingForReload">
+          <template v-slot:activator="{ on }">
+            <span v-on="on">
+              <VBtn
+                :to="{
+                  name: 'edit-track',
+                  params: { id: track.id },
+                  query: { redirect: $route.fullPath },
+                }"
+                :disabled="waitingForReload"
+                color="edit"
+                class="ma-1"
+                text
+                icon
+                small
+              >
+                <VIcon>mdi-pencil</VIcon>
+              </VBtn>
+            </span>
+          </template>
+          <span>{{ $t("common.disabled-while-loading") }}</span>
+        </VTooltip>
+        <VTooltip bottom :disabled="!waitingForReload">
+          <template v-slot:activator="{ on }">
+            <span v-on="on">
+              <VBtn
+                @click.stop.prevent="deleteTrack"
+                :disabled="waitingForReload"
+                color="danger"
+                class="ma-1"
+                text
+                icon
+                small
+              >
+                <VIcon>mdi-delete</VIcon>
+              </VBtn>
+            </span>
+          </template>
+          <span>{{ $t("common.disabled-while-loading") }}</span>
+        </VTooltip>
       </span>
     </VSlideXReverseTransition>
   </span>

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -37,57 +37,48 @@
       <span>{{ $t("music.track.empty") }}</span>
     </VTooltip>
     <EditReviewComment :item="track" :update="flag" v-if="!isModerator" />
-    <VMenu v-model="expanded" offset-y v-else class="">
-      <template v-slot:activator="{ on }">
-        <span v-on="on">
-          <VBtn class="ma-1" color="edit" small icon>
-            <VIcon v-if="expanded">mdi-close</VIcon>
-            <VIcon v-else>mdi-arrow-expand-down</VIcon>
-          </VBtn>
-        </span>
-      </template>
-      <VList dense>
-        <VListItem class="px-0">
-          <VListContent class="py-0">
-            <EditReviewComment :item="track" :update="flag" />
-          </VListContent>
-        </VListItem>
-        <VListItem class="px-0">
-          <VListItemContent class="py-0">
-            <VBtn
-              :to="{
-                name: 'edit-track',
-                params: { id: track.id },
-                query: { redirect: $route.fullPath },
-              }"
-              :disabled="waitingForReload"
-              color="edit"
-              class="ma-1 flex-grow-0 flex-basis-auto"
-              text
-              icon
-              small
-            >
-              <VIcon>mdi-pencil</VIcon>
-            </VBtn>
-          </VListItemContent>
-        </VListItem>
-        <VLisstItem class="px-0">
-          <VListItemContent class="py-0">
-            <VBtn
-              @click.stop.prevent="deleteTrack"
-              :disabled="waitingForReload"
-              color="danger"
-              class="ma-1 flex-grow-0 flex-basis-auto"
-              text
-              icon
-              small
-            >
-              <VIcon>mdi-delete</VIcon>
-            </VBtn>
-          </VListItemContent>
-        </VLisstItem>
-      </VList>
-    </VMenu>
+    <VBtn
+      class="ma-1"
+      color="edit"
+      small
+      icon
+      @click.stop="expanded = !expanded"
+    >
+      <VIcon v-if="expanded">mdi-arrow-expand-left</VIcon>
+      <VIcon v-else>mdi-arrow-expand-right</VIcon>
+    </VBtn>
+    <VSlideXReverseTransition>
+      <span v-show="expanded">
+        <EditReviewComment :item="track" :update="flag" />
+        <VBtn
+          :to="{
+            name: 'edit-track',
+            params: { id: track.id },
+            query: { redirect: $route.fullPath },
+          }"
+          :disabled="waitingForReload"
+          color="edit"
+          class="ma-1 flex-grow-0 flex-basis-auto"
+          text
+          icon
+          small
+        >
+          <VIcon>mdi-pencil</VIcon>
+        </VBtn>
+
+        <VBtn
+          @click.stop.prevent="deleteTrack"
+          :disabled="waitingForReload"
+          color="danger"
+          class="ma-1 flex-grow-0 flex-basis-auto"
+          text
+          icon
+          small
+        >
+          <VIcon>mdi-delete</VIcon>
+        </VBtn>
+      </span>
+    </VSlideXReverseTransition>
   </span>
 </template>
 

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -36,50 +36,58 @@
       </template>
       <span>{{ $t("music.track.empty") }}</span>
     </VTooltip>
-    <EditReviewComment :item="track" :update="flag" />
-    <VTooltip bottom :disabled="!waitingForReload">
+    <EditReviewComment :item="track" :update="flag" v-if="!isModerator" />
+    <VMenu v-model="expanded" offset-y v-else class="">
       <template v-slot:activator="{ on }">
         <span v-on="on">
-          <VBtn
-            :to="{
-              name: 'edit-track',
-              params: { id: track.id },
-              query: { redirect: $route.fullPath },
-            }"
-            v-if="isModerator"
-            :disabled="waitingForReload"
-            color="edit"
-            class="ma-1"
-            text
-            icon
-            small
-          >
-            <VIcon>mdi-pencil</VIcon>
+          <VBtn class="ma-1" color="edit" small icon>
+            <VIcon v-if="expanded">mdi-close</VIcon>
+            <VIcon v-else>mdi-arrow-expand-down</VIcon>
           </VBtn>
         </span>
       </template>
-      <span>{{ $t("common.disabled-while-loading") }}</span>
-    </VTooltip>
-    <VTooltip bottom :disabled="!waitingForReload">
-      <template v-slot:activator="{ on }">
-        <span v-on="on">
-          <VBtn
-            @click.stop.prevent="deleteTrack"
-            v-if="isModerator"
-            :disabled="waitingForReload"
-            color="danger"
-            class="ma-1"
-            href="#"
-            text
-            icon
-            small
-          >
-            <VIcon>mdi-delete</VIcon>
-          </VBtn>
-        </span>
-      </template>
-      <span>{{ $t("common.disabled-while-loading") }}</span>
-    </VTooltip>
+      <VList dense>
+        <VListItem class="px-0">
+          <VListContent class="py-0">
+            <EditReviewComment :item="track" :update="flag" />
+          </VListContent>
+        </VListItem>
+        <VListItem class="px-0">
+          <VListItemContent class="py-0">
+            <VBtn
+              :to="{
+                name: 'edit-track',
+                params: { id: track.id },
+                query: { redirect: $route.fullPath },
+              }"
+              :disabled="waitingForReload"
+              color="edit"
+              class="ma-1 flex-grow-0 flex-basis-auto"
+              text
+              icon
+              small
+            >
+              <VIcon>mdi-pencil</VIcon>
+            </VBtn>
+          </VListItemContent>
+        </VListItem>
+        <VLisstItem class="px-0">
+          <VListItemContent class="py-0">
+            <VBtn
+              @click.stop.prevent="deleteTrack"
+              :disabled="waitingForReload"
+              color="danger"
+              class="ma-1 flex-grow-0 flex-basis-auto"
+              text
+              icon
+              small
+            >
+              <VIcon>mdi-delete</VIcon>
+            </VBtn>
+          </VListItemContent>
+        </VLisstItem>
+      </VList>
+    </VMenu>
   </span>
 </template>
 
@@ -92,6 +100,11 @@ export default {
   components: { EditReviewComment },
   props: {
     track: { type: Object, required: true },
+  },
+  data() {
+    return {
+      expanded: false,
+    };
   },
   computed: {
     ...mapGetters("auth", ["isModerator"]),

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -36,7 +36,7 @@
       </template>
       <span>{{ $t("music.track.empty") }}</span>
     </VTooltip>
-    <EditReviewComment :item="track" :update="flag"/>
+    <EditReviewComment :item="track" :update="flag" />
     <VMenu>
       <template v-slot:activator="{ on, attrs }">
         <VBtn class="ma-1" small icon v-bind="attrs" v-on="on">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -284,8 +284,8 @@
 		},
 		"title": "Title",
 		"track": {
-			"delete": "Verwijder nummer",
-			"edit": "Pas nummer aan",
+			"delete": "Delete track",
+			"edit": "Edit track",
 			"empty": "This track does not have audio.",
 			"length": "Length",
 			"number": "Number",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -284,6 +284,8 @@
 		},
 		"title": "Title",
 		"track": {
+			"delete": "Verwijder nummer",
+			"edit": "Pas nummer aan",
 			"empty": "This track does not have audio.",
 			"length": "Length",
 			"number": "Number",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -280,6 +280,8 @@
 		},
 		"title": "Titel",
 		"track": {
+			"delete": "Verwijder nummer",
+			"edit": "Pas nummer aan",
 			"empty": "Dit nummer heeft geen audio.",
 			"length": "Lengte",
 			"number": "Tracknummer",


### PR DESCRIPTION
I'm not sure about the icon. Proposals for an alternative are welcome.

This doesn't include the tooltip to notify users that edit/delete is unavailable during loading, but the buttons are still available.