### PR TITLE
Allow user to search in normalized_*

### DIFF
--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -176,7 +176,8 @@ export default {
           !this.search ||
           item.title
             .toLocaleLowerCase()
-            .indexOf(this.search.toLocaleLowerCase()) >= 0
+            .indexOf(this.search.toLocaleLowerCase()) >= 0 ||
+          item.normalized_title.indexOf(this.search.toLocaleLowerCase()) >= 0
       );
     },
     selectedIds() {

--- a/src/views/albums/Albums.vue
+++ b/src/views/albums/Albums.vue
@@ -81,7 +81,8 @@ export default {
           !this.search ||
           item.title
             .toLocaleLowerCase()
-            .indexOf(this.search.toLocaleLowerCase()) >= 0
+            .indexOf(this.search.toLocaleLowerCase()) >= 0 ||
+          item.normalized_title.indexOf(this.search.toLocaleLowerCase()) >= 0
       );
     },
   },

--- a/src/views/artists/Artists.vue
+++ b/src/views/artists/Artists.vue
@@ -74,7 +74,8 @@ export default {
           !this.search ||
           item.name
             .toLocaleLowerCase()
-            .indexOf(this.search.toLocaleLowerCase()) >= 0
+            .indexOf(this.search.toLocaleLowerCase()) >= 0 ||
+          item.normalized_name.indexOf(this.search.toLocaleLowerCase()) >= 0
       );
     },
   },

--- a/src/views/genres/Genres.vue
+++ b/src/views/genres/Genres.vue
@@ -64,7 +64,8 @@ export default {
           !this.search ||
           item.name
             .toLocaleLowerCase()
-            .indexOf(this.search.toLocaleLowerCase()) >= 0
+            .indexOf(this.search.toLocaleLowerCase()) >= 0 ||
+          item.normalized_name.indexOf(this.search.toLocaleLowerCase()) >= 0
       );
     },
   },

--- a/src/views/labels/Label.vue
+++ b/src/views/labels/Label.vue
@@ -87,7 +87,8 @@ export default {
           !this.search ||
           item.title
             .toLocaleLowerCase()
-            .indexOf(this.search.toLocaleLowerCase()) >= 0
+            .indexOf(this.search.toLocaleLowerCase()) >= 0 ||
+          item.normalized_title.indexOf(this.search.toLocaleLowerCase()) >= 0
       );
     },
   },

--- a/src/views/labels/Labels.vue
+++ b/src/views/labels/Labels.vue
@@ -65,7 +65,8 @@ export default {
           !this.search ||
           item.name
             .toLocaleLowerCase()
-            .indexOf(this.search.toLocaleLowerCase()) >= 0
+            .indexOf(this.search.toLocaleLowerCase()) >= 0 ||
+          item.normalized_name.indexOf(this.search.toLocaleLowerCase()) >= 0
       );
     },
     numberOfItems() {


### PR DESCRIPTION
fix #28 

This implementation allows the user to search either without any diacretics and get all results matching the normalized_* attribute or search with diacretics and only get the exact result. If a user searches with diacretics they have to get all diacretics in the name/title right.

As mentioned IRL, I would like to make this more complex in the future.