### PR TITLE
Allow user to filter on normalized_* in selects

### DIFF
--- a/src/components/AlbumForm.vue
+++ b/src/components/AlbumForm.vue
@@ -141,6 +141,7 @@
           <VCol class="flex-column">
             <VCombobox
               :items="sortedArtists"
+              :filter="filterName"
               item-text="name"
               item-value="id"
               :label="$tc('music.artists', 1)"
@@ -167,6 +168,7 @@
           <VCol class="flex-column">
             <VCombobox
               :items="sortedLabels"
+              :filter="filterName"
               item-text="name"
               item-value="id"
               :label="$tc('music.labels', 1)"
@@ -273,6 +275,13 @@ export default {
       createArtist: "artists/create",
       createLabel: "labels/create",
     }),
+    filterName(item, queryText, itemText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.name.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_name.indexOf(search) > -1
+      );
+    },
     fillValues() {
       this.newAlbum.title = this.album.title;
       this.newAlbum.release = this.album.release;

--- a/src/components/ArtistMergeDialog.vue
+++ b/src/components/ArtistMergeDialog.vue
@@ -31,6 +31,7 @@
             <VCol cols="12">
               <VCombobox
                 :items="sortedArtists"
+                :filter="filterName"
                 cache-items
                 item-text="name"
                 item-value="id"
@@ -85,6 +86,13 @@ export default {
   },
   methods: {
     ...mapActions("artists", ["merge"]),
+    filterName(item, queryText, itemText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.name.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_name.indexOf(search) > -1
+      );
+    },
     mergeArtists() {
       this.merge({ newID: this.mergeArtist.id, oldID: this.artist.id }).finally(
         () => {

--- a/src/components/GenreMergeDialog.vue
+++ b/src/components/GenreMergeDialog.vue
@@ -31,6 +31,7 @@
             <VCol cols="12">
               <VCombobox
                 :items="sortedGenres"
+                :filter="filterName"
                 cache-items
                 item-text="name"
                 item-value="id"
@@ -85,6 +86,13 @@ export default {
   },
   methods: {
     ...mapActions("genres", ["merge"]),
+    filterName(item, queryText, itemText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.name.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_name.indexOf(search) > -1
+      );
+    },
     mergeGenres() {
       this.merge({ newID: this.mergeGenre.id, oldID: this.genre.id }).finally(
         () => {

--- a/src/components/LabelMergeDialog.vue
+++ b/src/components/LabelMergeDialog.vue
@@ -31,6 +31,7 @@
             <VCol cols="12">
               <VCombobox
                 :items="sortedLabels"
+                :filter="filterName"
                 cache-items
                 item-text="name"
                 item-value="id"
@@ -85,6 +86,13 @@ export default {
   },
   methods: {
     ...mapActions("labels", ["merge"]),
+    filterName(item, queryText, itemText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.name.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_name.indexOf(search) > -1
+      );
+    },
     mergeLabels() {
       this.merge({ newID: this.mergeLabel.id, oldID: this.label.id }).finally(
         () => {

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -156,6 +156,7 @@
                 <VCol cols="12" sm="6">
                   <VAutocomplete
                     :items="sortedAlbums"
+                    :filter="filterTitle"
                     item-text="title"
                     item-value="id"
                     label="Album"
@@ -191,6 +192,7 @@
                 <VCol cols="12" sm="6">
                   <VCombobox
                     :items="sortedGenres"
+                    :filter="filterName"
                     cache-items
                     chips
                     deletable-chips
@@ -260,6 +262,7 @@
                 <VCol v-if="changeArtists.enabled">
                   <VCombobox
                     :items="sortedArtists"
+                    :filter="filterName"
                     item-text="name"
                     item-value="id"
                     :label="$tc('music.artists', 2)"
@@ -462,6 +465,20 @@ export default {
       createArtist: "artists/create",
       createGenre: "genres/create",
     }),
+    filterName(item, queryText, itemText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.name.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_name.indexOf(search) > -1
+      );
+    },
+    filterTitle(item, queryText, itemText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.title.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_title.indexOf(search) > -1
+      );
+    },
     saveTracks() {
       this.$refs.form.validate();
       if (!this.isValid) return false;

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -28,6 +28,7 @@
           />
           <VAutocomplete
             :items="sortedAlbums"
+            :filter="filterTitle"
             item-text="title"
             item-value="id"
             :label="$tc('music.albums', 1)"
@@ -35,6 +36,7 @@
           />
           <VCombobox
             :items="sortedGenres"
+            :filter="filterName"
             cache-items
             chips
             deletable-chips
@@ -79,6 +81,7 @@
             <VCol>
               <VCombobox
                 :items="sortedArtists"
+                :filter="filterName"
                 item-text="name"
                 item-value="id"
                 :label="$tc('music.artists', 1)"
@@ -239,6 +242,20 @@ export default {
       createArtist: "artists/create",
       createGenre: "genres/create",
     }),
+    filterName(item, queryText, itemText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.name.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_name.indexOf(search) > -1
+      );
+    },
+    filterTitle(item, queryText, itemText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.title.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_title.indexOf(search) > -1
+      );
+    },
     fillValues() {
       this.newTrack.number = this.track.number;
       this.newTrack.title = this.track.title;


### PR DESCRIPTION
This PR allows user to filter both on the name/title of an item and the normalized_* of that item. The logic for filtering is the same as in #228 

This changes the behaviour of all `VAutocomplete` and `VCombobox`, expect for the one in `CodecConversionForm`.

