### PR TITLE
Show rescan as running if started by another session

### DIFF
--- a/src/views/Library.vue
+++ b/src/views/Library.vue
@@ -119,7 +119,10 @@ export default {
     ...mapState("rescan", ["rescan"]),
     ...mapState("rescan", ["lastClick"]),
     rescanRunning() {
-      return this.lastClick > new Date(this.rescan.finished_at) ? true : false;
+      return this.rescan.running ||
+        this.lastClick > new Date(this.rescan.finished_at)
+        ? true
+        : false;
     },
   },
   methods: {


### PR DESCRIPTION
If the rescan runner was started by another session, it starts to automatically reload show, but this wasn't reflected by the button to start the runner