### PR TITLE
Use generic functions for all API calls

### DIFF
--- a/src/api/auth_tokens.js
+++ b/src/api/auth_tokens.js
@@ -1,23 +1,15 @@
-import baseURL from "./base_url";
-import { indexGenerator, destroy as genDestroy } from "./fetch";
+import {
+  indexGenerator,
+  create as genCreate,
+  destroy as genDestroy,
+} from "./fetch";
 
 export function index(auth) {
   return indexGenerator("auth_tokens", auth);
 }
 
 export function create(data) {
-  return fetch(`${baseURL}/auth_tokens/`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(data),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate(`auth_tokens`, {}, { ...data });
 }
 
 export function destroy(auth, id) {

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -40,10 +40,10 @@ export async function* indexGenerator(path, auth) {
   }
 }
 
-async function resolveRequest(request) {
+async function resolveRequest(path, options) {
   let response;
   try {
-    response = await fetchRetry(request);
+    response = await fetchRetry(`${baseURL}/${path}`, options);
   } catch (reason) {
     throw { error: [reason] };
   }
@@ -56,7 +56,7 @@ async function resolveRequest(request) {
 }
 
 export async function create(path, auth, object) {
-  const request = new Request(`${baseURL}/${path}`, {
+  const options = {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -64,24 +64,24 @@ export async function create(path, auth, object) {
       "x-device-id": auth?.device_id,
     },
     body: JSON.stringify(object),
-  });
-  return await resolveRequest(request);
+  };
+  return await resolveRequest(path, options);
 }
 
 export async function read(path, auth, retryOptions = {}) {
-  const request = new Request(`${baseURL}/${path}`, {
+  const options = {
     ...retryOptions,
     method: "GET",
     headers: {
       "x-secret": auth.secret,
       "x-device-id": auth.device_id,
     },
-  });
-  return await resolveRequest(request);
+  };
+  return await resolveRequest(path, options);
 }
 
 export async function update(path, auth, object) {
-  const request = new Request(`${baseURL}/${path}`, {
+  const options = {
     method: "PATCH",
     headers: {
       "content-type": "application/json",
@@ -89,41 +89,41 @@ export async function update(path, auth, object) {
       "x-device-id": auth.device_id,
     },
     body: JSON.stringify(object),
-  });
-  return await resolveRequest(request);
+  };
+  return await resolveRequest(path, options);
 }
 
 export async function destroy(path, auth) {
-  const request = new Request(`${baseURL}/${path}`, {
+  const options = {
     method: "DELETE",
     headers: {
       "x-secret": auth.secret,
       "x-device-id": auth.device_id,
     },
-  });
-  return await resolveRequest(request);
+  };
+  return await resolveRequest(path, options);
 }
 
 export async function destroyEmpty(path, auth) {
-  const request = new Request(`${baseURL}/${path}/destroy_empty`, {
+  const options = {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-secret": auth.secret,
       "x-device-id": auth.device_id,
     },
-  });
-  return await resolveRequest(request);
+  };
+  return await resolveRequest(path, options);
 }
 
 export async function merge(path, auth) {
-  const request = new Request(`${baseURL}/${path}`, {
+  const options = {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-secret": auth.secret,
       "x-device-id": auth.device_id,
     },
-  });
-  return await resolveRequest(request);
+  };
+  return await resolveRequest(path, options);
 }

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -1,6 +1,9 @@
 import baseURL from "./base_url";
 const fetchRetry = require("fetch-retry")(fetch, {
   retries: 0,
+  retryDelay: function (attempt) {
+    return Math.pow(2, attempt) * 15000;
+  },
 });
 
 export async function* indexGenerator(path, auth) {
@@ -10,9 +13,6 @@ export async function* indexGenerator(path, auth) {
     try {
       response = await fetchRetry(`${baseURL}/${path}?page=${page}`, {
         retries: 5,
-        retryDelay: function (attempt) {
-          return Math.pow(2, attempt) * 15000;
-        },
         method: "GET",
         headers: {
           "x-secret": auth.secret,
@@ -60,8 +60,8 @@ export async function create(path, auth, object) {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
+      "x-secret": auth?.secret,
+      "x-device-id": auth?.device_id,
     },
     body: JSON.stringify(object),
   });

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -1,5 +1,7 @@
 import baseURL from "./base_url";
-const fetchRetry = require("fetch-retry")(fetch);
+const fetchRetry = require("fetch-retry")(fetch, {
+  retries: 0,
+});
 
 export async function* indexGenerator(path, auth) {
   let page = 1;
@@ -41,7 +43,7 @@ export async function* indexGenerator(path, auth) {
 async function resolveRequest(request) {
   let response;
   try {
-    response = await fetch(request);
+    response = await fetchRetry(request);
   } catch (reason) {
     throw { error: [reason] };
   }
@@ -66,8 +68,9 @@ export async function create(path, auth, object) {
   return await resolveRequest(request);
 }
 
-export async function read(path, auth) {
+export async function read(path, auth, retryOptions = {}) {
   const request = new Request(`${baseURL}/${path}`, {
+    ...retryOptions,
     method: "GET",
     headers: {
       "x-secret": auth.secret,

--- a/src/api/rescan.js
+++ b/src/api/rescan.js
@@ -1,36 +1,12 @@
-import baseURL from "./base_url";
-const fetchRetry = require("fetch-retry")(fetch);
+import { create as genCreate, read as genRead } from "./fetch";
 
 export function show(auth) {
-  return fetchRetry(`${baseURL}/rescan`, {
-    retries: 5,
-    retryDelay: function (attempt) {
-      return Math.pow(2, attempt) * 15000;
-    },
-    method: "GET",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  const retryDelay = function (attempt) {
+    return Math.pow(2, attempt) * 15000;
+  };
+  return genRead("rescan", auth, { retries: 5, retryDelay });
 }
 
 export function start(auth) {
-  return fetch(`${baseURL}/rescan`, {
-    method: "POST",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return genCreate("rescan", auth);
 }

--- a/src/api/rescan.js
+++ b/src/api/rescan.js
@@ -1,10 +1,7 @@
 import { create as genCreate, read as genRead } from "./fetch";
 
 export function show(auth) {
-  const retryDelay = function (attempt) {
-    return Math.pow(2, attempt) * 15000;
-  };
-  return genRead("rescan", auth, { retries: 5, retryDelay });
+  return genRead("rescan", auth, { retries: 5 });
 }
 
 export function start(auth) {


### PR DESCRIPTION
Refactor to use the generic create and read functions from `fetch.js` for the rescan start and show api calls and creating auth_tokens.