### PR TITLE
Fetch object before allowing edits

### DIFF
--- a/src/api/albums.js
+++ b/src/api/albums.js
@@ -1,6 +1,7 @@
 import {
   indexGenerator,
   create as genCreate,
+  read as genRead,
   update as genUpdate,
   destroy as genDestroy,
   destroyEmpty as genDestroyEmpty,
@@ -12,6 +13,10 @@ export function index(auth) {
 
 export function create(auth, album) {
   return genCreate("albums", auth, { album });
+}
+
+export function read(auth, id) {
+  return genRead(`albums/${id}`, auth);
 }
 
 export function update(auth, id, album) {

--- a/src/api/artists.js
+++ b/src/api/artists.js
@@ -1,6 +1,7 @@
 import {
   indexGenerator,
   create as genCreate,
+  read as genRead,
   update as genUpdate,
   destroy as genDestroy,
   destroyEmpty as genDestroyEmpty,
@@ -13,6 +14,10 @@ export function index(auth) {
 
 export function create(auth, artist) {
   return genCreate("artists", auth, { artist });
+}
+
+export function read(auth, id) {
+  return genRead(`artists/${id}`, auth);
 }
 
 export function update(auth, id, artist) {

--- a/src/api/genres.js
+++ b/src/api/genres.js
@@ -1,6 +1,7 @@
 import {
   indexGenerator,
   create as genCreate,
+  read as genRead,
   update as genUpdate,
   destroy as genDestroy,
   destroyEmpty as genDestroyEmpty,
@@ -13,6 +14,10 @@ export function index(auth) {
 
 export function create(auth, genre) {
   return genCreate("genres", auth, { genre });
+}
+
+export function read(auth, id) {
+  return genRead(`genres/${id}`, auth);
 }
 
 export function update(auth, id, genre) {

--- a/src/api/labels.js
+++ b/src/api/labels.js
@@ -1,6 +1,7 @@
 import {
   indexGenerator,
   create as genCreate,
+  read as genRead,
   update as genUpdate,
   destroy as genDestroy,
   destroyEmpty as genDestroyEmpty,
@@ -13,6 +14,10 @@ export function index(auth) {
 
 export function create(auth, label) {
   return genCreate("labels", auth, { label });
+}
+
+export function read(auth, id) {
+  return genRead(`labels/${id}`, auth);
 }
 
 export function update(auth, id, label) {

--- a/src/components/AlbumForm.vue
+++ b/src/components/AlbumForm.vue
@@ -270,11 +270,10 @@ export default {
     };
   },
   created() {
-    this.$nextTick(() => {
-      if (this.album) {
+    if (this.album)
+      this.read(this.album.id).then(() => {
         this.fillValues();
-      }
-    });
+      });
   },
   watch: {
     album: function () {
@@ -295,7 +294,7 @@ export default {
     }),
   },
   methods: {
-    ...mapActions("albums", ["create", "update"]),
+    ...mapActions("albums", ["create", "read", "update"]),
     ...mapActions({
       createArtist: "artists/create",
       createLabel: "labels/create",

--- a/src/components/ArtistForm.vue
+++ b/src/components/ArtistForm.vue
@@ -51,11 +51,10 @@ export default {
     };
   },
   created() {
-    this.$nextTick(() => {
-      if (this.artist) {
+    if (this.artist)
+      this.read(this.artist.id).then(() => {
         this.fillValues();
-      }
-    });
+      });
   },
   watch: {
     artist: function () {
@@ -65,7 +64,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions("artists", ["create", "update"]),
+    ...mapActions("artists", ["create", "read", "update"]),
     fillValues() {
       this.newArtist.name = this.artist.name;
       this.newArtist.review_comment = this.artist.review_comment;

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -123,13 +123,16 @@ export default {
           return Promise.resolve(false);
         });
     },
-    async read({ commit, rootState }, id) {
-      try {
-        const album = await read(rootState.auth, id);
-        commit("setAlbum", { id, album });
-      } catch (error) {
-        this.commit("addError", error);
-      }
+    read({ commit, rootState }, id) {
+      return read(rootState.auth, id)
+        .then((result) => {
+          commit("setAlbum", { id, album: result });
+          return Promise.resolve(result.id);
+        })
+        .catch((error) => {
+          this.commit("addError", error);
+          return Promise.resolve(false);
+        });
     },
     update({ commit, rootState }, { id, newAlbum }) {
       return update(rootState.auth, id, newAlbum)

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -1,5 +1,12 @@
 import Vue from "vue";
-import { index, create, destroy, update, destroyEmpty } from "../api/albums";
+import {
+  index,
+  create,
+  read,
+  destroy,
+  update,
+  destroyEmpty,
+} from "../api/albums";
 import { fetchAll } from "./actions";
 import { compareStrings } from "../comparators";
 
@@ -115,6 +122,14 @@ export default {
           this.commit("addError", error);
           return Promise.resolve(false);
         });
+    },
+    async read({ commit, rootState }, id) {
+      try {
+        const album = await read(rootState.auth, id);
+        commit("setAlbum", { id, album });
+      } catch (error) {
+        this.commit("addError", error);
+      }
     },
     update({ commit, rootState }, { id, newAlbum }) {
       return update(rootState.auth, id, newAlbum)

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -2,6 +2,7 @@ import Vue from "vue";
 import {
   index,
   create,
+  read,
   destroy,
   update,
   destroyEmpty,
@@ -74,6 +75,14 @@ export default {
           this.commit("addError", error);
           return Promise.resolve(false);
         });
+    },
+    async read({ commit, rootState }, id) {
+      try {
+        const artist = await read(rootState.auth, id);
+        commit("setArtist", { id, artist });
+      } catch (error) {
+        this.commit("addError", error);
+      }
     },
     update({ commit, rootState }, { id, newArtist }) {
       return update(rootState.auth, id, newArtist)

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -76,13 +76,16 @@ export default {
           return Promise.resolve(false);
         });
     },
-    async read({ commit, rootState }, id) {
-      try {
-        const artist = await read(rootState.auth, id);
-        commit("setArtist", { id, artist });
-      } catch (error) {
-        this.commit("addError", error);
-      }
+    read({ commit, rootState }, id) {
+      return read(rootState.auth, id)
+        .then((result) => {
+          commit("setArtist", { id, artist: result });
+          return Promise.resolve(result.id);
+        })
+        .catch((error) => {
+          this.commit("addError", error);
+          return Promise.resolve(false);
+        });
     },
     update({ commit, rootState }, { id, newArtist }) {
       return update(rootState.auth, id, newArtist)

--- a/src/store/genres.js
+++ b/src/store/genres.js
@@ -75,6 +75,14 @@ export default {
           return Promise.resolve(false);
         });
     },
+    async read({ commit, rootState }, id) {
+      try {
+        const genre = await read(rootState.auth, id);
+        commit("setGenre", { id, genre });
+      } catch (error) {
+        this.commit("addError", error);
+      }
+    },
     update({ commit, rootState }, { id, newGenre }) {
       return update(rootState.auth, id, newGenre)
         .then((result) => {

--- a/src/store/genres.js
+++ b/src/store/genres.js
@@ -75,13 +75,16 @@ export default {
           return Promise.resolve(false);
         });
     },
-    async read({ commit, rootState }, id) {
-      try {
-        const genre = await read(rootState.auth, id);
-        commit("setGenre", { id, genre });
-      } catch (error) {
-        this.commit("addError", error);
-      }
+    read({ commit, rootState }, id) {
+      return read(rootState.auth, id)
+        .then((result) => {
+          commit("setGenre", { id, genre: result });
+          return Promise.resolve(result.id);
+        })
+        .catch((error) => {
+          this.commit("addError", error);
+          return Promise.resolve(false);
+        });
     },
     update({ commit, rootState }, { id, newGenre }) {
       return update(rootState.auth, id, newGenre)

--- a/src/store/labels.js
+++ b/src/store/labels.js
@@ -75,13 +75,16 @@ export default {
           return Promise.resolve(false);
         });
     },
-    async read({ commit, rootState }, id) {
-      try {
-        const label = await read(rootState.auth, id);
-        commit("setLabel", { id, label });
-      } catch (error) {
-        this.commit("addError", error);
-      }
+    read({ commit, rootState }, id) {
+      return read(rootState.auth, id)
+        .then((result) => {
+          commit("setLabel", { id, label: result });
+          return Promise.resolve(result.id);
+        })
+        .catch((error) => {
+          this.commit("addError", error);
+          return Promise.resolve(false);
+        });
     },
     update({ commit, rootState }, { id, newLabel }) {
       return update(rootState.auth, id, newLabel)

--- a/src/store/labels.js
+++ b/src/store/labels.js
@@ -75,6 +75,14 @@ export default {
           return Promise.resolve(false);
         });
     },
+    async read({ commit, rootState }, id) {
+      try {
+        const label = await read(rootState.auth, id);
+        commit("setLabel", { id, label });
+      } catch (error) {
+        this.commit("addError", error);
+      }
+    },
     update({ commit, rootState }, { id, newLabel }) {
       return update(rootState.auth, id, newLabel)
         .then((result) => {

--- a/src/views/genres/EditGenre.vue
+++ b/src/views/genres/EditGenre.vue
@@ -36,11 +36,10 @@ export default {
     };
   },
   created() {
-    this.$nextTick(() => {
-      if (this.genre) {
+    if (this.genre)
+      this.read(this.genre.id).then(() => {
         this.fillValues();
-      }
-    });
+      });
   },
   watch: {
     genre: function () {
@@ -56,7 +55,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions("genres", ["update"]),
+    ...mapActions("genres", ["read", "update"]),
     fillValues() {
       this.newGenre.name = this.genre.name;
     },

--- a/src/views/labels/EditLabel.vue
+++ b/src/views/labels/EditLabel.vue
@@ -36,11 +36,10 @@ export default {
     };
   },
   created() {
-    this.$nextTick(() => {
-      if (this.label) {
+    if (this.label)
+      this.read(this.label.id).then(() => {
         this.fillValues();
-      }
-    });
+      });
   },
   watch: {
     label: function () {
@@ -56,7 +55,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions("labels", ["update"]),
+    ...mapActions("labels", ["read", "update"]),
     fillValues() {
       this.newLabel.name = this.label.name;
     },

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -186,11 +186,10 @@ export default {
     };
   },
   created() {
-    this.$nextTick(() => {
-      if (this.track) {
+    if (this.track)
+      this.read(this.track.id).then(() => {
         this.fillValues();
-      }
-    });
+      });
   },
   watch: {
     track: function () {
@@ -251,7 +250,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions("tracks", ["update"]),
+    ...mapActions("tracks", ["read", "update"]),
     ...mapActions({
       createArtist: "artists/create",
       createGenre: "genres/create",


### PR DESCRIPTION
fix #73 
To prevent the user from overwriting changes they didn't see, we fetch the object when opening the editing form.