### PR TITLE
Create play after track has finished

### DIFF
--- a/src/api/plays.js
+++ b/src/api/plays.js
@@ -1,9 +1,9 @@
 import { indexGenerator, create as genCreate } from "./fetch";
 
 export function index(auth) {
-  return indexGenerator("albums", auth);
+  return indexGenerator("plays", auth);
 }
 
 export function create(auth, play) {
-  return genCreate(`plays`, auth, { play });
+  return genCreate("plays", auth, { play });
 }

--- a/src/api/plays.js
+++ b/src/api/plays.js
@@ -1,4 +1,8 @@
-import { create as genCreate } from "./fetch";
+import { indexGenerator, create as genCreate } from "./fetch";
+
+export function index(auth) {
+  return indexGenerator("albums", auth);
+}
 
 export function create(auth, play) {
   return genCreate(`plays`, auth, { play });

--- a/src/api/plays.js
+++ b/src/api/plays.js
@@ -1,0 +1,5 @@
+import { create as genCreate } from "./fetch";
+
+export function create(auth, play) {
+  return genCreate(`plays`, auth, { play });
+}

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -141,7 +141,7 @@
 </template>
 
 <script>
-import { mapGetters, mapMutations, mapState } from "vuex";
+import { mapActions, mapGetters, mapMutations, mapState } from "vuex";
 import Draggable from "vuedraggable";
 import TrackArtists from "./TrackArtists";
 
@@ -160,6 +160,7 @@ export default {
     this.intervalId = setInterval(this.checkTime, 100);
     this.$nextTick(() =>
       this.$refs.audio.addEventListener("ended", () => {
+        this.create_play(this.currentTrack.id);
         this.trackEnded();
       })
     );
@@ -308,6 +309,7 @@ export default {
     },
   },
   methods: {
+    ...mapActions("tracks", ["create_play"]),
     ...mapMutations("player", [
       "setSeekTime",
       "seek",

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -160,7 +160,7 @@ export default {
     this.intervalId = setInterval(this.checkTime, 100);
     this.$nextTick(() =>
       this.$refs.audio.addEventListener("ended", () => {
-        this.create_play(this.currentTrack.id);
+        this.createPlay(this.currentTrack.id);
         this.trackEnded();
       })
     );
@@ -309,7 +309,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions("tracks", ["create_play"]),
+    ...mapActions("plays", { createPlay: "create" }),
     ...mapMutations("player", [
       "setSeekTime",
       "seek",

--- a/src/store/plays.js
+++ b/src/store/plays.js
@@ -1,0 +1,71 @@
+import { index, create } from "../api/plays";
+import { fetchAll } from "./actions";
+
+export default {
+  namespaced: true,
+  state: {
+    plays: {},
+    startLoading: new Date(0),
+  },
+  mutations: {
+    setPlays(state, payload) {
+      const oldPlays = state.plays;
+      state.plays = {};
+      for (let id in oldPlays) {
+        state.plays[id] = oldPlays[id];
+      }
+      for (let play of payload) {
+        state.plays[play.id] = play;
+      }
+    },
+    setPlay(state, { id, play }) {
+      const oldPlays = state.plays;
+      state.plays = {};
+      for (let id in oldPlays) {
+        state.plays[id] = oldPlays[id];
+      }
+      play.loaded = new Date();
+      state.plays[id] = play;
+    },
+    setStartLoading(state) {
+      state.startLoading = new Date();
+    },
+    removeOld(state) {
+      const oldPlays = state.plays;
+      state.plays = {};
+      for (let id in oldPlays) {
+        if (oldPlays[id].loaded > state.startLoading) {
+          state.plays[id] = oldPlays[id];
+        }
+      }
+    },
+  },
+  actions: {
+    async index({ commit, rootState }) {
+      const generator = index(rootState.auth);
+      try {
+        await fetchAll(commit, generator, "setPlays");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
+    },
+    async create({ commit, rootState }, track_id) {
+      try {
+        const result = await create(rootState.auth, {
+          track_id,
+          played_at: new Date(),
+        });
+        commit("setPlay", { id: result.id, play: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
+    },
+  },
+  getters: {
+    plays: (state) => Object.values(state.plays),
+  },
+};

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -12,6 +12,7 @@ import imageTypes from "./image_types";
 import labels from "./labels";
 import locations from "./locations";
 import player from "./player";
+import plays from "./plays";
 import rescan from "./rescan";
 import tracks from "./tracks";
 import users from "./users";
@@ -38,6 +39,7 @@ export default new Vuex.Store({
     labels,
     locations,
     player,
+    plays,
     rescan,
     tracks,
     users,

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -1,6 +1,5 @@
 import Vue from "vue";
 import { index, create, destroy, update, read, merge } from "../api/tracks";
-import { create as create_play } from "../api/plays";
 import { fetchAll } from "./actions";
 import { compareTracks } from "../comparators";
 
@@ -116,17 +115,6 @@ export default {
       } catch (error) {
         commit("addError", error, { root: true });
         return false;
-      }
-    },
-    async create_play({ commit, dispatch, rootState }, id) {
-      try {
-        await create_play(rootState.auth, {
-          track_id: id,
-          played_at: new Date(),
-        });
-        await dispatch("read", id);
-      } catch (error) {
-        commit("addError", error, { root: true });
       }
     },
     async read({ commit, rootState }, id) {

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import { index, create, destroy, update, read, merge } from "../api/tracks";
+import { create as create_play } from "../api/plays";
 import { fetchAll } from "./actions";
 import { compareTracks } from "../comparators";
 
@@ -116,6 +117,20 @@ export default {
         commit("addError", error, { root: true });
         return false;
       }
+    },
+    create_play({ commit, rootState }, id) {
+      return create_play(rootState.auth, {
+        track_id: id,
+        user_id: rootState.auth.user_id,
+        played_at: new Date(),
+      })
+        .then((result) => {
+          return Promise.resolve(result.id);
+        })
+        .catch((error) => {
+          this.commit("addError", error);
+          return Promise.resolve(false);
+        });
     },
     async read({ commit, rootState }, id) {
       try {

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -118,19 +118,17 @@ export default {
         return false;
       }
     },
-    create_play({ commit, rootState }, id) {
-      return create_play(rootState.auth, {
-        track_id: id,
-        user_id: rootState.auth.user_id,
-        played_at: new Date(),
-      })
-        .then((result) => {
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
+    async create_play({ commit, dispatch, rootState }, id) {
+      try {
+        await create_play(rootState.auth, {
+          track_id: id,
+          user_id: rootState.auth.user_id,
+          played_at: new Date(),
         });
+        await dispatch("read", id);
+      } catch (error) {
+        commit("addError", error, { root: true });
+      }
     },
     async read({ commit, rootState }, id) {
       try {

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -122,7 +122,6 @@ export default {
       try {
         await create_play(rootState.auth, {
           track_id: id,
-          user_id: rootState.auth.user_id,
           played_at: new Date(),
         });
         await dispatch("read", id);


### PR DESCRIPTION
depends on accentor/api#114

There is a good argument to create a play when we reach 75%, 80%, 90%, ... of the tracks length, but for the moment I've just attached to to the `ended`-event.

I put the actions inside plays, since play data will live inside the track and not get a separate module.

