### PR TITLE
Switch promise to async syntax for store and API

### DIFF
--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -4,9 +4,9 @@ const fetchRetry = require("fetch-retry")(fetch);
 export async function* indexGenerator(path, auth) {
   let page = 1;
   while (true) {
-    let request;
+    let response;
     try {
-      request = await fetchRetry(`${baseURL}/${path}?page=${page}`, {
+      response = await fetchRetry(`${baseURL}/${path}?page=${page}`, {
         retries: 5,
         retryDelay: function (attempt) {
           return Math.pow(2, attempt) * 15000;
@@ -20,13 +20,13 @@ export async function* indexGenerator(path, auth) {
     } catch (reason) {
       throw { error: [reason] };
     }
-    const result = await request.json();
-    if (request.ok && result) {
+    const result = await response.json();
+    if (response.ok && result) {
       const loaded = new Date();
       for (let obj in result) {
         result[obj].loaded = loaded;
       }
-      if (request.headers.get("x-total-pages") == page) {
+      if (response.headers.get("x-total-pages") == page) {
         return result;
       } else {
         yield result;

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -4,19 +4,22 @@ const fetchRetry = require("fetch-retry")(fetch);
 export async function* indexGenerator(path, auth) {
   let page = 1;
   while (true) {
-    const request = await fetchRetry(`${baseURL}/${path}?page=${page}`, {
-      retries: 5,
-      retryDelay: function (attempt) {
-        return Math.pow(2, attempt) * 15000;
-      },
-      method: "GET",
-      headers: {
-        "x-secret": auth.secret,
-        "x-device-id": auth.device_id,
-      },
-    }).catch((reason) => {
+    let request;
+    try {
+      request = await fetchRetry(`${baseURL}/${path}?page=${page}`, {
+        retries: 5,
+        retryDelay: function (attempt) {
+          return Math.pow(2, attempt) * 15000;
+        },
+        method: "GET",
+        headers: {
+          "x-secret": auth.secret,
+          "x-device-id": auth.device_id,
+        },
+      });
+    } catch (reason) {
       throw { error: [reason] };
-    });
+    }
     const result = await request.json();
     if (request.ok && result) {
       const loaded = new Date();
@@ -36,9 +39,12 @@ export async function* indexGenerator(path, auth) {
 }
 
 async function resolveRequest(request) {
-  const response = await fetch(request).catch((reason) => {
+  let response;
+  try {
+    response = await fetch(request);
+  } catch (reason) {
     throw { error: [reason] };
-  });
+  }
   const result = await response.json();
   if (response.ok) {
     return result;

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -47,7 +47,7 @@ async function resolveRequest(request) {
   }
 }
 
-export function create(path, auth, object) {
+export async function create(path, auth, object) {
   const request = new Request(`${baseURL}/${path}`, {
     method: "POST",
     headers: {
@@ -57,10 +57,10 @@ export function create(path, auth, object) {
     },
     body: JSON.stringify(object),
   });
-  return resolveRequest(request);
+  return await resolveRequest(request);
 }
 
-export function read(path, auth) {
+export async function read(path, auth) {
   const request = new Request(`${baseURL}/${path}`, {
     method: "GET",
     headers: {
@@ -68,10 +68,10 @@ export function read(path, auth) {
       "x-device-id": auth.device_id,
     },
   });
-  return resolveRequest(request);
+  return await resolveRequest(request);
 }
 
-export function update(path, auth, object) {
+export async function update(path, auth, object) {
   const request = new Request(`${baseURL}/${path}`, {
     method: "PATCH",
     headers: {
@@ -81,7 +81,7 @@ export function update(path, auth, object) {
     },
     body: JSON.stringify(object),
   });
-  return resolveRequest(request);
+  return await resolveRequest(request);
 }
 
 export async function destroy(path, auth) {
@@ -92,10 +92,10 @@ export async function destroy(path, auth) {
       "x-device-id": auth.device_id,
     },
   });
-  return resolveRequest(request);
+  return await resolveRequest(request);
 }
 
-export function destroyEmpty(path, auth) {
+export async function destroyEmpty(path, auth) {
   const request = new Request(`${baseURL}/${path}/destroy_empty`, {
     method: "POST",
     headers: {
@@ -104,10 +104,10 @@ export function destroyEmpty(path, auth) {
       "x-device-id": auth.device_id,
     },
   });
-  return resolveRequest(request);
+  return await resolveRequest(request);
 }
 
-export function merge(path, auth) {
+export async function merge(path, auth) {
   const request = new Request(`${baseURL}/${path}`, {
     method: "POST",
     headers: {
@@ -116,5 +116,5 @@ export function merge(path, auth) {
       "x-device-id": auth.device_id,
     },
   });
-  return resolveRequest(request);
+  return await resolveRequest(request);
 }

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -35,101 +35,92 @@ export async function* indexGenerator(path, auth) {
   }
 }
 
+async function resolveRequest(asyncCallback) {
+  const request = await asyncCallback.catch((reason) => {
+    throw { error: [reason] };
+  });
+  const result = await request.json();
+  if (request.ok) {
+    return result;
+  } else {
+    throw result;
+  }
+}
+
 export function create(path, auth, object) {
-  return fetch(`${baseURL}/${path}`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify(object),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return resolveRequest(
+    fetch(`${baseURL}/${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-secret": auth.secret,
+        "x-device-id": auth.device_id,
+      },
+      body: JSON.stringify(object),
+    })
+  );
 }
 
 export function read(path, auth) {
-  return fetch(`${baseURL}/${path}`, {
-    method: "GET",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return resolveRequest(
+    fetch(`${baseURL}/${path}`, {
+      method: "GET",
+      headers: {
+        "x-secret": auth.secret,
+        "x-device-id": auth.device_id,
+      },
+    })
+  );
 }
 
 export function update(path, auth, object) {
-  return fetch(`${baseURL}/${path}`, {
-    method: "PATCH",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-    body: JSON.stringify(object),
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => Promise.all([request.ok, request.json()]))
-    .then(([ok, result]) => {
-      return ok ? Promise.resolve(result) : Promise.reject(result);
-    });
+  return resolveRequest(
+    fetch(`${baseURL}/${path}`, {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        "x-secret": auth.secret,
+        "x-device-id": auth.device_id,
+      },
+      body: JSON.stringify(object),
+    })
+  );
 }
 
-export function destroy(path, auth) {
-  return fetch(`${baseURL}/${path}`, {
-    method: "DELETE",
-    headers: {
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+export async function destroy(path, auth) {
+  return resolveRequest(
+    fetch(`${baseURL}/${path}`, {
+      method: "DELETE",
+      headers: {
+        "x-secret": auth.secret,
+        "x-device-id": auth.device_id,
+      },
+    })
+  );
 }
 
 export function destroyEmpty(path, auth) {
-  return fetch(`${baseURL}/${path}/destroy_empty`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return resolveRequest(
+    fetch(`${baseURL}/${path}/destroy_empty`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-secret": auth.secret,
+        "x-device-id": auth.device_id,
+      },
+    })
+  );
 }
 
 export function merge(path, auth) {
-  return fetch(`${baseURL}/${path}`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      "x-secret": auth.secret,
-      "x-device-id": auth.device_id,
-    },
-  })
-    .catch((reason) => Promise.reject({ error: [reason] }))
-    .then((request) => {
-      return request.ok
-        ? Promise.resolve()
-        : request.json().then((result) => Promise.reject(result));
-    });
+  return resolveRequest(
+    fetch(`${baseURL}/${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-secret": auth.secret,
+        "x-device-id": auth.device_id,
+      },
+    })
+  );
 }

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -35,12 +35,12 @@ export async function* indexGenerator(path, auth) {
   }
 }
 
-async function resolveRequest(asyncCallback) {
-  const request = await asyncCallback.catch((reason) => {
+async function resolveRequest(request) {
+  const response = await fetch(request).catch((reason) => {
     throw { error: [reason] };
   });
-  const result = await request.json();
-  if (request.ok) {
+  const result = await response.json();
+  if (response.ok) {
     return result;
   } else {
     throw result;
@@ -48,79 +48,73 @@ async function resolveRequest(asyncCallback) {
 }
 
 export function create(path, auth, object) {
-  return resolveRequest(
-    fetch(`${baseURL}/${path}`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-secret": auth.secret,
-        "x-device-id": auth.device_id,
-      },
-      body: JSON.stringify(object),
-    })
-  );
+  const request = new Request(`${baseURL}/${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+    body: JSON.stringify(object),
+  });
+  return resolveRequest(request);
 }
 
 export function read(path, auth) {
-  return resolveRequest(
-    fetch(`${baseURL}/${path}`, {
-      method: "GET",
-      headers: {
-        "x-secret": auth.secret,
-        "x-device-id": auth.device_id,
-      },
-    })
-  );
+  const request = new Request(`${baseURL}/${path}`, {
+    method: "GET",
+    headers: {
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+  });
+  return resolveRequest(request);
 }
 
 export function update(path, auth, object) {
-  return resolveRequest(
-    fetch(`${baseURL}/${path}`, {
-      method: "PATCH",
-      headers: {
-        "content-type": "application/json",
-        "x-secret": auth.secret,
-        "x-device-id": auth.device_id,
-      },
-      body: JSON.stringify(object),
-    })
-  );
+  const request = new Request(`${baseURL}/${path}`, {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+    body: JSON.stringify(object),
+  });
+  return resolveRequest(request);
 }
 
 export async function destroy(path, auth) {
-  return resolveRequest(
-    fetch(`${baseURL}/${path}`, {
-      method: "DELETE",
-      headers: {
-        "x-secret": auth.secret,
-        "x-device-id": auth.device_id,
-      },
-    })
-  );
+  const request = new Request(`${baseURL}/${path}`, {
+    method: "DELETE",
+    headers: {
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+  });
+  return resolveRequest(request);
 }
 
 export function destroyEmpty(path, auth) {
-  return resolveRequest(
-    fetch(`${baseURL}/${path}/destroy_empty`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-secret": auth.secret,
-        "x-device-id": auth.device_id,
-      },
-    })
-  );
+  const request = new Request(`${baseURL}/${path}/destroy_empty`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+  });
+  return resolveRequest(request);
 }
 
 export function merge(path, auth) {
-  return resolveRequest(
-    fetch(`${baseURL}/${path}`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-secret": auth.secret,
-        "x-device-id": auth.device_id,
-      },
-    })
-  );
+  const request = new Request(`${baseURL}/${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-secret": auth.secret,
+      "x-device-id": auth.device_id,
+    },
+  });
+  return resolveRequest(request);
 }

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -101,70 +101,65 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setAlbums")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setAlbums");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newAlbum) {
-      return create(rootState.auth, newAlbum)
-        .then((result) => {
-          commit("setAlbum", { id: result.id, album: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newAlbum) {
+      try {
+        const result = await create(rootState.auth, newAlbum);
+        commit("setAlbum", { id: result.id, album: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    read({ commit, rootState }, id) {
-      return read(rootState.auth, id)
-        .then((result) => {
-          commit("setAlbum", { id, album: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async read({ commit, rootState }, id) {
+      try {
+        const result = await read(rootState.auth, id);
+        commit("setAlbum", { id, album: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    update({ commit, rootState }, { id, newAlbum }) {
-      return update(rootState.auth, id, newAlbum)
-        .then((result) => {
-          commit("setAlbum", { id, album: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newAlbum }) {
+      try {
+        const result = await update(rootState.auth, id, newAlbum);
+        commit("setAlbum", { id, album: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("removeAlbum", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("removeAlbum", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroyEmpty({ rootState }) {
-      return destroyEmpty(rootState.auth)
-        .then(() => {
-          return this.dispatch("albums/index");
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroyEmpty({ commit, dispatch, rootState }) {
+      try {
+        await destroyEmpty(rootState.auth);
+        dispatch("index");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -54,72 +54,67 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setArtists")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setArtists");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newArtist) {
-      return create(rootState.auth, newArtist)
-        .then((result) => {
-          commit("setArtist", { id: result.id, artist: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newArtist) {
+      try {
+        const result = await create(rootState.auth, newArtist);
+        commit("setArtist", { id: result.id, artist: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    read({ commit, rootState }, id) {
-      return read(rootState.auth, id)
-        .then((result) => {
-          commit("setArtist", { id, artist: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async read({ commit, rootState }, id) {
+      try {
+        const result = await read(rootState.auth, id);
+        commit("setArtist", { id, artist: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    update({ commit, rootState }, { id, newArtist }) {
-      return update(rootState.auth, id, newArtist)
-        .then((result) => {
-          commit("setArtist", { id, artist: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newArtist }) {
+      try {
+        const result = await update(rootState.auth, id, newArtist);
+        commit("setArtist", { id, artist: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("albums/removeArtistOccurence", id, { root: true });
-          commit("tracks/removeArtistOccurence", id, { root: true });
-          commit("removeArtist", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("albums/removeArtistOccurence", id, { root: true });
+        commit("tracks/removeArtistOccurence", id, { root: true });
+        commit("removeArtist", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroyEmpty({ rootState }) {
-      return destroyEmpty(rootState.auth)
-        .then(() => {
-          return this.dispatch("artists/index");
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroyEmpty({ commit, dispatch, rootState }) {
+      try {
+        await destroyEmpty(rootState.auth);
+        dispatch("index");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
     async merge({ commit, rootState }, { newID, oldID }) {
       try {
@@ -135,8 +130,10 @@ export default {
           { root: true }
         );
         commit("removeArtist", oldID);
+        return true;
       } catch (error) {
-        this.commit("addError", error);
+        commit("addError", error, { root: true });
+        return false;
       }
     },
   },

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -52,49 +52,45 @@ export default {
     },
   },
   actions: {
-    login(context, data) {
-      return create(data)
-        .then((result) => {
-          context.commit("login", result);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async login({ commit }, data) {
+      try {
+        const result = await create(data);
+        commit("login", result);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    logout({ commit, state }) {
-      return destroy(state, state.id)
-        .then(() => {
-          commit("logout");
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async logout({ commit, state }) {
+      try {
+        await destroy(state, state.id);
+        commit("logout");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setAuthTokens")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setAuthTokens");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("removeAuthToken", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("removeAuthToken", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/codec_conversions.js
+++ b/src/store/codec_conversions.js
@@ -45,52 +45,48 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setCodecConversions")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setCodecConversions");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newCodecConversion) {
-      return create(rootState.auth, newCodecConversion)
-        .then((result) => {
-          commit("setCodecConversion", {
-            id: result.id,
-            codecConversion: result,
-          });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
+    async create({ commit, rootState }, newCodecConversion) {
+      try {
+        const result = await create(rootState.auth, newCodecConversion);
+        commit("setCodecConversion", {
+          id: result.id,
+          codecConversion: result,
         });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    update({ commit, rootState }, { id, newCodecConversion }) {
-      return update(rootState.auth, id, newCodecConversion)
-        .then((result) => {
-          commit("setCodecConversion", { id, codecConversion: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newCodecConversion }) {
+      try {
+        const result = await update(rootState.auth, id, newCodecConversion);
+        commit("setCodecConversion", { id, codecConversion: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("removeCodecConversion", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("removeCodecConversion", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/codecs.js
+++ b/src/store/codecs.js
@@ -45,49 +45,45 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setCodecs")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setCodecs");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newCodec) {
-      return create(rootState.auth, newCodec)
-        .then((result) => {
-          commit("setCodec", { id: result.id, codec: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newCodec) {
+      try {
+        const result = await create(rootState.auth, newCodec);
+        commit("setCodec", { id: result.id, codec: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    update({ commit, rootState }, { id, newCodec }) {
-      return update(rootState.auth, id, newCodec)
-        .then((result) => {
-          commit("setCodec", { id, codec: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newCodec }) {
+      try {
+        const result = await update(rootState.auth, id, newCodec);
+        commit("setCodec", { id, codec: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("removeCodec", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("removeCodec", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/cover_filenames.js
+++ b/src/store/cover_filenames.js
@@ -45,49 +45,45 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setCoverFilenames")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setCoverFilenames");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newCoverFilename) {
-      return create(rootState.auth, newCoverFilename)
-        .then((result) => {
-          commit("setCoverFilename", { id: result.id, coverFilename: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newCoverFilename) {
+      try {
+        const result = await create(rootState.auth, newCoverFilename);
+        commit("setCoverFilename", { id: result.id, coverFilename: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    update({ commit, rootState }, { id, newCoverFilename }) {
-      return update(rootState.auth, id, newCoverFilename)
-        .then((result) => {
-          commit("setCoverFilename", { id, coverFilename: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newCoverFilename }) {
+      try {
+        const result = await update(rootState.auth, id, newCoverFilename);
+        commit("setCoverFilename", { id, coverFilename: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("removeCoverFilename", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("removeCoverFilename", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/genres.js
+++ b/src/store/genres.js
@@ -4,6 +4,7 @@ import {
   create,
   read,
   destroy,
+  read,
   update,
   destroyEmpty,
   merge,
@@ -54,86 +55,77 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setGenres")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setGenres");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newGenre) {
-      return create(rootState.auth, newGenre)
-        .then((result) => {
-          commit("setGenre", { id: result.id, genre: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newGenre) {
+      try {
+        const result = await create(rootState.auth, newGenre);
+        commit("setGenre", { id: result.id, genre: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    read({ commit, rootState }, id) {
-      return read(rootState.auth, id)
-        .then((result) => {
-          commit("setGenre", { id, genre: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async read({ commit, rootState }, id) {
+      try {
+        const result = await read(rootState.auth, id);
+        commit("setGenre", { id, genre: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    update({ commit, rootState }, { id, newGenre }) {
-      return update(rootState.auth, id, newGenre)
-        .then((result) => {
-          commit("setGenre", { id, genre: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newGenre }) {
+      try {
+        const result = await update(rootState.auth, id, newGenre);
+        commit("setGenre", { id, genre: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("tracks/removeGenreOccurence", id, { root: true });
-          commit("removeGenre", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("tracks/removeGenreOccurence", id, { root: true });
+        commit("removeGenre", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroyEmpty({ rootState }) {
-      return destroyEmpty(rootState.auth)
-        .then(() => {
-          return this.dispatch("genres/index");
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroyEmpty({ commit, dispatch, rootState }) {
+      try {
+        await destroyEmpty(rootState.auth);
+        dispatch("index");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    merge({ commit, rootState }, { newID, oldID }) {
-      return merge(rootState.auth, newID, oldID)
-        .then(() => {
-          commit(
-            "tracks/updateGenreOccurence",
-            { newID, oldID },
-            { root: true }
-          );
-          commit("removeGenre", oldID);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async merge({ commit, rootState }, { newID, oldID }) {
+      try {
+        await merge(rootState.auth, newID, oldID);
+        commit("tracks/updateGenreOccurence", { newID, oldID }, { root: true });
+        commit("removeGenre", oldID);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/genres.js
+++ b/src/store/genres.js
@@ -4,7 +4,6 @@ import {
   create,
   read,
   destroy,
-  read,
   update,
   destroyEmpty,
   merge,

--- a/src/store/image_types.js
+++ b/src/store/image_types.js
@@ -45,49 +45,45 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setImageTypes")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setImageTypes");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newImageType) {
-      return create(rootState.auth, newImageType)
-        .then((result) => {
-          commit("setImageType", { id: result.id, imageType: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newImageType) {
+      try {
+        const result = await create(rootState.auth, newImageType);
+        commit("setImageType", { id: result.id, imageType: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    update({ commit, rootState }, { id, newImageType }) {
-      return update(rootState.auth, id, newImageType)
-        .then((result) => {
-          commit("setImageType", { id, imageType: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newImageType }) {
+      try {
+        const result = await update(rootState.auth, id, newImageType);
+        commit("setImageType", { id, imageType: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("removeImageType", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("removeImageType", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/labels.js
+++ b/src/store/labels.js
@@ -54,86 +54,77 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setLabels")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setLabels");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newLabel) {
-      return create(rootState.auth, newLabel)
-        .then((result) => {
-          commit("setLabel", { id: result.id, label: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newLabel) {
+      try {
+        const result = await create(rootState.auth, newLabel);
+        commit("setLabel", { id: result.id, label: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    read({ commit, rootState }, id) {
-      return read(rootState.auth, id)
-        .then((result) => {
-          commit("setLabel", { id, label: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async read({ commit, rootState }, id) {
+      try {
+        const result = read(rootState.auth, id);
+        commit("setLabel", { id, label: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    update({ commit, rootState }, { id, newLabel }) {
-      return update(rootState.auth, id, newLabel)
-        .then((result) => {
-          commit("setLabel", { id, label: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newLabel }) {
+      try {
+        const result = await update(rootState.auth, id, newLabel);
+        commit("setLabel", { id, label: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("albums/removeLabelOccurence", id, { root: true });
-          commit("removeLabel", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("albums/removeLabelOccurence", id, { root: true });
+        commit("removeLabel", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroyEmpty({ rootState }) {
-      return destroyEmpty(rootState.auth)
-        .then(() => {
-          return this.dispatch("labels/index");
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroyEmpty({ commit, dispatch, rootState }) {
+      try {
+        await destroyEmpty(rootState.auth);
+        dispatch("index");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    merge({ commit, rootState }, { newID, oldID }) {
-      return merge(rootState.auth, newID, oldID)
-        .then(() => {
-          commit(
-            "albums/updateLabelOccurence",
-            { newID, oldID },
-            { root: true }
-          );
-          commit("removeLabel", oldID);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async merge({ commit, rootState }, { newID, oldID }) {
+      try {
+        await merge(rootState.auth, newID, oldID);
+        commit("albums/updateLabelOccurence", { newID, oldID }, { root: true });
+        commit("removeLabel", oldID);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/locations.js
+++ b/src/store/locations.js
@@ -45,38 +45,35 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setLocations")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setLocations");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newLocation) {
-      return create(rootState.auth, newLocation)
-        .then((result) => {
-          commit("setLocation", { id: result.id, location: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newLocation) {
+      try {
+        const result = await create(rootState.auth, newLocation);
+        commit("setLocation", { id: result.id, location: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("removeLocation", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("removeLocation", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/rescan.js
+++ b/src/store/rescan.js
@@ -15,36 +15,34 @@ export default {
     },
   },
   actions: {
-    show({ commit, dispatch, rootState }) {
-      return show(rootState.auth)
-        .then((result) => {
-          commit("setRescan", result);
-          if (
-            rootState.rescan.lastClick > new Date(result.finished_at) ||
-            result.running
-          ) {
-            setTimeout(() => dispatch("show"), 1000);
-          }
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
-    },
-    start({ commit, dispatch, rootState }) {
-      commit("setLastClick", new Date());
-      return start(rootState.auth)
-        .then((result) => {
-          result.running = true;
-          commit("setRescan", result);
+    async show({ commit, dispatch, rootState }) {
+      try {
+        const result = await show(rootState.auth);
+        commit("setRescan", result);
+        if (
+          rootState.rescan.lastClick > new Date(result.finished_at) ||
+          result.running
+        ) {
           setTimeout(() => dispatch("show"), 1000);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+        }
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
+    },
+    async start({ commit, dispatch, rootState }) {
+      commit("setLastClick", new Date());
+      try {
+        const result = await start(rootState.auth);
+        result.running = true;
+        commit("setRescan", result);
+        setTimeout(() => dispatch("show"), 1000);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -97,65 +97,65 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setTracks")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setTracks");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newTrack) {
-      return create(rootState.auth, newTrack)
-        .then((result) => {
-          commit("setTrack", { id: result.id, track: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newTrack) {
+      try {
+        const result = await create(rootState.auth, newTrack);
+        commit("setTrack", { id: result.id, track: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
     async read({ commit, rootState }, id) {
       try {
         const track = await read(rootState.auth, id);
         commit("setTrack", { id, track });
+        return true;
       } catch (error) {
-        this.commit("addError", error);
+        commit("addError", error, { root: true });
+        return false;
       }
     },
-    update({ commit, rootState }, { id, newTrack }) {
-      return update(rootState.auth, id, newTrack)
-        .then((result) => {
-          commit("setTrack", { id, track: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newTrack }) {
+      try {
+        const result = await update(rootState.auth, id, newTrack);
+        commit("setTrack", { id, track: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("removeTrack", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("removeTrack", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
     async merge({ commit, dispatch, rootState }, { newID, oldID }) {
       try {
         await merge(rootState.auth, newID, oldID);
         await dispatch("read", newID);
         commit("removeTrack", oldID);
+        return true;
       } catch (error) {
-        this.commit("addError", error);
+        commit("addError", error, { root: true });
+        return false;
       }
     },
   },

--- a/src/store/users.js
+++ b/src/store/users.js
@@ -46,49 +46,45 @@ export default {
     },
   },
   actions: {
-    index({ commit, rootState }) {
+    async index({ commit, rootState }) {
       const generator = index(rootState.auth);
-      return fetchAll(commit, generator, "setUsers")
-        .then(() => {
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+      try {
+        await fetchAll(commit, generator, "setUsers");
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    create({ commit, rootState }, newUser) {
-      return create(rootState.auth, newUser)
-        .then((result) => {
-          commit("setUser", { id: result.id, user: result });
-          return Promise.resolve(result.id);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async create({ commit, rootState }, newUser) {
+      try {
+        const result = await create(rootState.auth, newUser);
+        commit("setUser", { id: result.id, user: result });
+        return result.id;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    update({ commit, rootState }, { id, newUser }) {
-      return update(rootState.auth, id, newUser)
-        .then((result) => {
-          commit("setUser", { id, user: result });
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async update({ commit, rootState }, { id, newUser }) {
+      try {
+        const result = await update(rootState.auth, id, newUser);
+        commit("setUser", { id, user: result });
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
-    destroy({ commit, rootState }, id) {
-      return destroy(rootState.auth, id)
-        .then(() => {
-          commit("removeUser", id);
-          return Promise.resolve(true);
-        })
-        .catch((error) => {
-          this.commit("addError", error);
-          return Promise.resolve(false);
-        });
+    async destroy({ commit, rootState }, id) {
+      try {
+        await destroy(rootState.auth, id);
+        commit("removeUser", id);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
     },
   },
   getters: {


### PR DESCRIPTION
re #279 
(I would not yet close this issue, as we still use Promises inside some of the vue templates - we might also want to switch there?)

For the store I've made two additional adjustments, to get more consistent actions:
1. An action always return something, either an id (in case of create) or true or false. (Before we had some that returned true or false and some that didn't)
2. Avoid using the global `this` of the store: `dispatch` and `commit` are always used from the actions context, with `{ root: true }` where necessary. This IMHO more clear (and we were using both at the same time