### PR TITLE
Switch to async syntax in vue SFC

### DIFF
--- a/src/components/AlbumForm.vue
+++ b/src/components/AlbumForm.vue
@@ -359,7 +359,7 @@ export default {
         this.newAlbum.album_artists.splice(index, 1)[0]
       );
     },
-    submit() {
+    async submit() {
       const transformed = {
         title: this.newAlbum.title,
         release: this.newAlbum.release,
@@ -375,52 +375,44 @@ export default {
         album_artists: [],
       };
 
-      const promises = [];
-
-      for (let label of this.newAlbum.album_labels) {
+      const label_map = this.newAlbum.album_labels.map(async (label) => {
         if (typeof label.label_id === "string") {
-          promises.push(
-            this.createLabel({ name: label.label_id }).then((id) => {
-              if (id) {
-                transformed.album_labels.push({
-                  label_id: id,
-                  catalogue_number: label.catalogue_number,
-                });
-              } else {
-                return Promise.reject();
-              }
-            })
-          );
+          const id = await this.createLabel({ name: label.label_id });
+          if (id) {
+            transformed.album_labels.push({
+              label_id: id,
+              catalogue_number: label.catalogue_number,
+            });
+          } else {
+            throw false;
+          }
         } else {
           transformed.album_labels.push({
             label_id: label.label_id.id,
             catalogue_number: label.catalogue_number,
           });
         }
-      }
+      });
 
-      this.newAlbum.album_artists.forEach((aa, index) => {
+      const artist_map = this.newAlbum.album_artists.map(async (aa, index) => {
         if (typeof aa.artist_id === "string") {
-          promises.push(
-            this.createArtist({
-              name: aa.artist_id,
-              review_comment: "New artist",
-            }).then((id) => {
-              if (id) {
-                transformed.album_artists.push({
-                  artist_id: id,
-                  name: aa.name || aa.artist_id,
-                  separator:
-                    index !== this.newAlbum.album_artists.length - 1
-                      ? aa.separator
-                      : null,
-                  order: index + 1,
-                });
-              } else {
-                return Promise.reject();
-              }
-            })
-          );
+          const id = await this.createArtist({
+            name: aa.artist_id,
+            review_comment: "New artist",
+          });
+          if (id) {
+            transformed.album_artists.push({
+              artist_id: id,
+              name: aa.name || aa.artist_id,
+              separator:
+                index !== this.newAlbum.album_artists.length - 1
+                  ? aa.separator
+                  : null,
+              order: index + 1,
+            });
+          } else {
+            throw false;
+          }
         } else {
           transformed.album_artists.push({
             artist_id: aa.artist_id.id,
@@ -434,19 +426,16 @@ export default {
         }
       });
 
-      Promise.all(promises).then(() => {
-        let promise = null;
-        if (this.album) {
-          promise = this.update({ id: this.album.id, newAlbum: transformed });
-        } else {
-          promise = this.create(transformed);
-        }
-        promise.then((succeeded) => {
-          if (succeeded) {
-            this.$router.push(this.$route.query.redirect || { name: "albums" });
-          }
-        });
-      });
+      await Promise.all([...artist_map, ...label_map]);
+      let promise = null;
+      if (this.album) {
+        promise = this.update({ id: this.album.id, newAlbum: transformed });
+      } else {
+        promise = this.create(transformed);
+      }
+      const succeeded = await promise;
+      if (succeeded)
+        this.$router.push(this.$route.query.redirect || { name: "albums" });
     },
   },
 };

--- a/src/components/AlbumForm.vue
+++ b/src/components/AlbumForm.vue
@@ -434,8 +434,9 @@ export default {
         promise = this.create(transformed);
       }
       const succeeded = await promise;
-      if (succeeded)
+      if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "albums" });
+      }
     },
   },
 };

--- a/src/components/AlbumForm.vue
+++ b/src/components/AlbumForm.vue
@@ -429,13 +429,16 @@ export default {
       );
 
       await Promise.all([...mappedArtists, ...mappedLabels]);
-      let promise = null;
+      let pendingResult = null;
       if (this.album) {
-        promise = this.update({ id: this.album.id, newAlbum: transformed });
+        pendingResult = this.update({
+          id: this.album.id,
+          newAlbum: transformed,
+        });
       } else {
-        promise = this.create(transformed);
+        pendingResult = this.create(transformed);
       }
-      const succeeded = await promise;
+      const succeeded = await pendingResult;
       if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "albums" });
       }

--- a/src/components/AlbumForm.vue
+++ b/src/components/AlbumForm.vue
@@ -375,7 +375,7 @@ export default {
         album_artists: [],
       };
 
-      const label_map = this.newAlbum.album_labels.map(async (label) => {
+      const mappedLabels = this.newAlbum.album_labels.map(async (label) => {
         if (typeof label.label_id === "string") {
           const id = await this.createLabel({ name: label.label_id });
           if (id) {
@@ -394,39 +394,41 @@ export default {
         }
       });
 
-      const artist_map = this.newAlbum.album_artists.map(async (aa, index) => {
-        if (typeof aa.artist_id === "string") {
-          const id = await this.createArtist({
-            name: aa.artist_id,
-            review_comment: "New artist",
-          });
-          if (id) {
+      const mappedArtists = this.newAlbum.album_artists.map(
+        async (aa, index) => {
+          if (typeof aa.artist_id === "string") {
+            const id = await this.createArtist({
+              name: aa.artist_id,
+              review_comment: "New artist",
+            });
+            if (id) {
+              transformed.album_artists.push({
+                artist_id: id,
+                name: aa.name || aa.artist_id,
+                separator:
+                  index !== this.newAlbum.album_artists.length - 1
+                    ? aa.separator
+                    : null,
+                order: index + 1,
+              });
+            } else {
+              throw false;
+            }
+          } else {
             transformed.album_artists.push({
-              artist_id: id,
-              name: aa.name || aa.artist_id,
+              artist_id: aa.artist_id.id,
+              name: aa.name || aa.artist_id.name,
               separator:
                 index !== this.newAlbum.album_artists.length - 1
                   ? aa.separator
                   : null,
               order: index + 1,
             });
-          } else {
-            throw false;
           }
-        } else {
-          transformed.album_artists.push({
-            artist_id: aa.artist_id.id,
-            name: aa.name || aa.artist_id.name,
-            separator:
-              index !== this.newAlbum.album_artists.length - 1
-                ? aa.separator
-                : null,
-            order: index + 1,
-          });
         }
-      });
+      );
 
-      await Promise.all([...artist_map, ...label_map]);
+      await Promise.all([...mappedArtists, ...mappedLabels]);
       let promise = null;
       if (this.album) {
         promise = this.update({ id: this.album.id, newAlbum: transformed });

--- a/src/components/ArtistForm.vue
+++ b/src/components/ArtistForm.vue
@@ -74,16 +74,16 @@ export default {
       this.newArtist.review_comment = this.clear_review_comment
         ? null
         : this.newArtist.review_comment;
-      let promise = null;
+      let pendingResult = null;
       if (this.artist) {
-        promise = this.update({
+        pendingResult = this.update({
           id: this.artist.id,
           newArtist: this.newArtist,
         });
       } else {
-        promise = this.create(this.newArtist);
+        pendingResult = this.create(this.newArtist);
       }
-      const succeeded = await promise;
+      const succeeded = await pendingResult;
       if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "artists" });
       }

--- a/src/components/ArtistForm.vue
+++ b/src/components/ArtistForm.vue
@@ -76,14 +76,17 @@ export default {
         : this.newArtist.review_comment;
       let promise = null;
       if (this.artist) {
-        const newArtist = { id: this.artist.id, newArtist: this.newArtist };
-        promise = this.update();
+        promise = this.update({
+          id: this.artist.id,
+          newArtist: this.newArtist,
+        });
       } else {
         promise = this.create(this.newArtist);
       }
       const succeeded = await promise;
-      if (succeeded)
+      if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "artists" });
+      }
     },
   },
 };

--- a/src/components/ArtistForm.vue
+++ b/src/components/ArtistForm.vue
@@ -70,24 +70,20 @@ export default {
       this.newArtist.name = this.artist.name;
       this.newArtist.review_comment = this.artist.review_comment;
     },
-    submit() {
+    async submit() {
       this.newArtist.review_comment = this.clear_review_comment
         ? null
         : this.newArtist.review_comment;
       let promise = null;
       if (this.artist) {
-        promise = this.update({
-          id: this.artist.id,
-          newArtist: this.newArtist,
-        });
+        const newArtist = { id: this.artist.id, newArtist: this.newArtist };
+        promise = this.update();
       } else {
         promise = this.create(this.newArtist);
       }
-      promise.then((succeeded) => {
-        if (succeeded) {
-          this.$router.push(this.$route.query.redirect || { name: "artists" });
-        }
-      });
+      const succeeded = await promise;
+      if (succeeded)
+        this.$router.push(this.$route.query.redirect || { name: "artists" });
     },
   },
 };

--- a/src/components/CodecConversionForm.vue
+++ b/src/components/CodecConversionForm.vue
@@ -111,18 +111,17 @@ export default {
       this.newCodecConversion.resulting_codec_id = this.codecConversion.resulting_codec_id;
     },
     ...mapActions("codecConversions", ["destroy", "update", "create"]),
-    saveCodecConversion() {
+    async saveCodecConversion() {
       if (this.$refs.form.validate()) {
         if (this.codecConversion === null) {
-          this.create(this.newCodecConversion).then((id) => {
-            if (id) {
-              this.newCodecConversion.name = "";
-              this.newCodecConversion.ffmpeg_params = "";
-              this.newCodecConversion.resulting_codec_id = null;
-            }
-          });
+          const id = await this.create(this.newCodecConversion);
+          if (id) {
+            this.newCodecConversion.name = "";
+            this.newCodecConversion.ffmpeg_params = "";
+            this.newCodecConversion.resulting_codec_id = null;
+          }
         } else {
-          this.update({
+          await this.update({
             id: this.codecConversion.id,
             newCodecConversion: this.newCodecConversion,
           });
@@ -130,9 +129,8 @@ export default {
       }
     },
     deleteCodecConversion() {
-      if (confirm(this.$t("common.are-you-sure"))) {
+      if (confirm(this.$t("common.are-you-sure")))
         this.destroy(this.codecConversion.id);
-      }
     },
   },
 };

--- a/src/components/CodecConversionForm.vue
+++ b/src/components/CodecConversionForm.vue
@@ -129,8 +129,9 @@ export default {
       }
     },
     deleteCodecConversion() {
-      if (confirm(this.$t("common.are-you-sure")))
+      if (confirm(this.$t("common.are-you-sure"))) {
         this.destroy(this.codecConversion.id);
+      }
     },
   },
 };

--- a/src/components/CodecForm.vue
+++ b/src/components/CodecForm.vue
@@ -97,24 +97,21 @@ export default {
       this.newCodec.mimetype = this.codec.mimetype;
     },
     ...mapActions("codecs", ["destroy", "update", "create"]),
-    saveCodec() {
+    async saveCodec() {
       if (this.$refs.form.validate()) {
         if (this.codec === null) {
-          this.create(this.newCodec).then((id) => {
-            if (id) {
-              this.newCodec.extension = "";
-              this.newCodec.mimetype = "";
-            }
-          });
+          const id = await this.create(this.newCodec);
+          if (id) {
+            this.newCodec.extension = "";
+            this.newCodec.mimetype = "";
+          }
         } else {
           this.update({ id: this.codec.id, newCodec: this.newCodec });
         }
       }
     },
     deleteCodec() {
-      if (confirm(this.$t("common.are-you-sure"))) {
-        this.destroy(this.codec.id);
-      }
+      if (confirm(this.$t("common.are-you-sure"))) this.destroy(this.codec.id);
     },
   },
 };

--- a/src/components/CodecForm.vue
+++ b/src/components/CodecForm.vue
@@ -111,7 +111,9 @@ export default {
       }
     },
     deleteCodec() {
-      if (confirm(this.$t("common.are-you-sure"))) this.destroy(this.codec.id);
+      if (confirm(this.$t("common.are-you-sure"))) {
+        this.destroy(this.codec.id);
+      }
     },
   },
 };

--- a/src/components/CoverFilenameForm.vue
+++ b/src/components/CoverFilenameForm.vue
@@ -70,19 +70,15 @@ export default {
       this.newCoverFilename.filename = this.coverFilename.filename;
     },
     ...mapActions("coverFilenames", ["destroy", "update", "create"]),
-    saveCoverFilename() {
+    async saveCoverFilename() {
       if (this.$refs.form.validate()) {
-        this.create(this.newCoverFilename).then((id) => {
-          if (id) {
-            this.newCoverFilename.filename = "";
-          }
-        });
+        const id = await this.create(this.newCoverFilename);
+        if (id) this.newCoverFilename.filename = "";
       }
     },
     deleteCoverFilename() {
-      if (confirm(this.$t("common.are-you-sure"))) {
+      if (confirm(this.$t("common.are-you-sure")))
         this.destroy(this.coverFilename.id);
-      }
     },
   },
 };

--- a/src/components/CoverFilenameForm.vue
+++ b/src/components/CoverFilenameForm.vue
@@ -73,12 +73,15 @@ export default {
     async saveCoverFilename() {
       if (this.$refs.form.validate()) {
         const id = await this.create(this.newCoverFilename);
-        if (id) this.newCoverFilename.filename = "";
+        if (id) {
+          this.newCoverFilename.filename = "";
+        }
       }
     },
     deleteCoverFilename() {
-      if (confirm(this.$t("common.are-you-sure")))
+      if (confirm(this.$t("common.are-you-sure"))) {
         this.destroy(this.coverFilename.id);
+      }
     },
   },
 };

--- a/src/components/EditReviewComment.vue
+++ b/src/components/EditReviewComment.vue
@@ -58,7 +58,9 @@ export default {
         this.item.id,
         this.new_review_comment
       );
-      if (succeeded) this.show = false;
+      if (succeeded) {
+        this.show = false;
+      }
     },
   },
 };

--- a/src/components/EditReviewComment.vue
+++ b/src/components/EditReviewComment.vue
@@ -53,12 +53,12 @@ export default {
     this.new_review_comment = this.item.review_comment;
   },
   methods: {
-    flag() {
-      this.update(this.item.id, this.new_review_comment).then((succeeded) => {
-        if (succeeded) {
-          this.show = false;
-        }
-      });
+    async flag() {
+      const succeeded = await this.update(
+        this.item.id,
+        this.new_review_comment
+      );
+      if (succeeded) this.show = false;
     },
   },
 };

--- a/src/components/EditReviewComment.vue
+++ b/src/components/EditReviewComment.vue
@@ -36,7 +36,7 @@ export default {
   data() {
     return {
       show: false,
-      new_review_comment: "",
+      newReviewComment: "",
     };
   },
   props: {
@@ -50,14 +50,11 @@ export default {
     },
   },
   created() {
-    this.new_review_comment = this.item.review_comment;
+    this.newReviewComment = this.item.review_comment;
   },
   methods: {
     async flag() {
-      const succeeded = await this.update(
-        this.item.id,
-        this.new_review_comment
-      );
+      const succeeded = await this.update(this.item.id, this.newReviewComment);
       if (succeeded) {
         this.show = false;
       }

--- a/src/components/ImageTypeForm.vue
+++ b/src/components/ImageTypeForm.vue
@@ -98,15 +98,14 @@ export default {
       this.newImageType.mimetype = this.imageType.mimetype;
     },
     ...mapActions("imageTypes", ["destroy", "update", "create"]),
-    saveImageType() {
+    async saveImageType() {
       if (this.$refs.form.validate()) {
         if (this.imageType === null) {
-          this.create(this.newImageType).then((id) => {
-            if (id) {
-              this.newImageType.extension = "";
-              this.newImageType.mimetype = "";
-            }
-          });
+          const id = await this.create(this.newImageType);
+          if (id) {
+            this.newImageType.extension = "";
+            this.newImageType.mimetype = "";
+          }
         } else {
           this.update({
             id: this.imageType.id,
@@ -116,9 +115,8 @@ export default {
       }
     },
     deleteImageType() {
-      if (confirm(this.$t("common.are-you-sure"))) {
+      if (confirm(this.$t("common.are-you-sure")))
         this.destroy(this.imageType.id);
-      }
     },
   },
 };

--- a/src/components/ImageTypeForm.vue
+++ b/src/components/ImageTypeForm.vue
@@ -115,8 +115,9 @@ export default {
       }
     },
     deleteImageType() {
-      if (confirm(this.$t("common.are-you-sure")))
+      if (confirm(this.$t("common.are-you-sure"))) {
         this.destroy(this.imageType.id);
+      }
     },
   },
 };

--- a/src/components/LocationForm.vue
+++ b/src/components/LocationForm.vue
@@ -90,12 +90,15 @@ export default {
     async saveLocation() {
       if (this.$refs.form.validate()) {
         const id = await this.create(this.newLocation);
-        if (id) this.newLocation.path = "";
+        if (id) {
+          this.newLocation.path = "";
+        }
       }
     },
     deleteLocation() {
-      if (confirm(this.$t("common.are-you-sure")))
+      if (confirm(this.$t("common.are-you-sure"))) {
         this.destroy(this.location.id);
+      }
     },
   },
 };

--- a/src/components/LocationForm.vue
+++ b/src/components/LocationForm.vue
@@ -87,19 +87,15 @@ export default {
       this.newLocation.path = this.location.path;
     },
     ...mapActions("locations", ["destroy", "update", "create"]),
-    saveLocation() {
+    async saveLocation() {
       if (this.$refs.form.validate()) {
-        this.create(this.newLocation).then((id) => {
-          if (id) {
-            this.newLocation.path = "";
-          }
-        });
+        const id = await this.create(this.newLocation);
+        if (id) this.newLocation.path = "";
       }
     },
     deleteLocation() {
-      if (confirm(this.$t("common.are-you-sure"))) {
+      if (confirm(this.$t("common.are-you-sure")))
         this.destroy(this.location.id);
-      }
     },
   },
 };

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -491,7 +491,7 @@ export default {
       const promises = [];
 
       if (this.changeArtists.enabled) {
-        const artist_map = this.changeArtists.track_artists.map(
+        const mappedArtists = this.changeArtists.track_artists.map(
           async (ta, index) => {
             if (typeof ta.artist_id === "string") {
               const id = await this.createArtist({
@@ -518,11 +518,11 @@ export default {
             }
           }
         );
-        promises.push(...artist_map);
+        promises.push(...mappedArtists);
       }
 
       if (this.changeGenres.enabled) {
-        const genre_map = this.changeGenres.genres.map(async (genre_id) => {
+        const mappedGenres = this.changeGenres.genres.map(async (genre_id) => {
           if (typeof genre_id === "string") {
             const id = await this.createGenre({ name: genre_id });
             if (id) {
@@ -534,11 +534,11 @@ export default {
             transformedGenres.push(genre_id.id);
           }
         });
-        promises.push(...genre_map);
+        promises.push(...mappedGenres);
       }
 
       await Promise.all(promises);
-      const track_map = this.tracks.map(async (t) => {
+      const mappedTracks = this.tracks.map(async (t) => {
         const transformed = {
           number: t.number,
           title: t.title,
@@ -604,7 +604,7 @@ export default {
 
         await this.update({ id: t.id, newTrack: transformed });
       });
-      await Promise.all(track_map);
+      await Promise.all(mappedTracks);
       this.dialog = false;
       this.resetState();
       this.saving = false;

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -488,7 +488,7 @@ export default {
       this.saving = true;
       const transformedArtists = [];
       const transformedGenres = [];
-      const promises = [];
+      const pendingResults = [];
 
       if (this.changeArtists.enabled) {
         const mappedArtists = this.changeArtists.track_artists.map(
@@ -518,7 +518,7 @@ export default {
             }
           }
         );
-        promises.push(...mappedArtists);
+        pendingResults.push(...mappedArtists);
       }
 
       if (this.changeGenres.enabled) {
@@ -534,10 +534,10 @@ export default {
             transformedGenres.push(genre_id.id);
           }
         });
-        promises.push(...mappedGenres);
+        pendingResults.push(...mappedGenres);
       }
 
-      await Promise.all(promises);
+      await Promise.all(pendingResults);
       const mappedTracks = this.tracks.map(async (t) => {
         const transformed = {
           number: t.number,

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -244,7 +244,7 @@ export default {
             navigator.mediaSession.playbackState = "playing";
           }
         } catch (error) {
-          new Error(error);
+          this.commit("addError", error);
         }
       } else {
         await this.$refs.audio.pause();

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -183,42 +183,40 @@ export default {
     this.setPlaying(false);
   },
   watch: {
-    currentTrackURL() {
+    async currentTrackURL() {
       this.$refs.audio.src = this.currentTrackURL;
       if (this.playing) {
-        this.$refs.audio
-          .play()
-          .then(() => {
-            if ("mediaSession" in navigator) {
-              navigator.mediaSession.metadata = new window.MediaMetadata({
-                title: this.currentTrack.title,
-                artist: this.currentTrack.track_artists
-                  .map((a) => a.name)
-                  .join(" / "),
-                album: this.albums[this.currentTrack.album_id].title,
-                artwork: [
-                  {
-                    src: this.albums[this.currentTrack.album_id].image100,
-                    sizes: "100x100",
-                    type: this.albums[this.currentTrack.album_id].image_type,
-                  },
-                  {
-                    src: this.albums[this.currentTrack.album_id].image250,
-                    sizes: "250x250",
-                    type: this.albums[this.currentTrack.album_id].image_type,
-                  },
-                  {
-                    src: this.albums[this.currentTrack.album_id].image500,
-                    sizes: "500x500",
-                    type: this.albums[this.currentTrack.album_id].image_type,
-                  },
-                ],
-              });
-            }
-          })
-          .catch((error) => {
-            this.commit("addError", error);
-          });
+        try {
+          await this.$refs.audio.play();
+          if ("mediaSession" in navigator) {
+            navigator.mediaSession.metadata = new window.MediaMetadata({
+              title: this.currentTrack.title,
+              artist: this.currentTrack.track_artists
+                .map((a) => a.name)
+                .join(" / "),
+              album: this.albums[this.currentTrack.album_id].title,
+              artwork: [
+                {
+                  src: this.albums[this.currentTrack.album_id].image100,
+                  sizes: "100x100",
+                  type: this.albums[this.currentTrack.album_id].image_type,
+                },
+                {
+                  src: this.albums[this.currentTrack.album_id].image250,
+                  sizes: "250x250",
+                  type: this.albums[this.currentTrack.album_id].image_type,
+                },
+                {
+                  src: this.albums[this.currentTrack.album_id].image500,
+                  sizes: "500x500",
+                  type: this.albums[this.currentTrack.album_id].image_type,
+                },
+              ],
+            });
+          }
+        } catch (error) {
+          this.commit("addError", error);
+        }
       }
     },
     volume() {
@@ -238,20 +236,18 @@ export default {
         }
       }
     },
-    playing() {
+    async playing() {
       if (this.playing) {
-        this.$refs.audio
-          .play()
-          .then(() => {
-            if ("mediaSession" in navigator) {
-              navigator.mediaSession.playbackState = "playing";
-            }
-          })
-          .catch((error) => {
-            new Error(error);
-          });
+        try {
+          await this.$refs.audio.play();
+          if ("mediaSession" in navigator) {
+            navigator.mediaSession.playbackState = "playing";
+          }
+        } catch (error) {
+          new Error(error);
+        }
       } else {
-        this.$refs.audio.pause();
+        await this.$refs.audio.pause();
         if ("mediaSession" in navigator) {
           navigator.mediaSession.playbackState = "paused";
         }

--- a/src/components/UserForm.vue
+++ b/src/components/UserForm.vue
@@ -122,7 +122,7 @@ export default {
       this.newUser.name = this.user.name;
       this.newUser.permission = this.user.permission;
     },
-    submit() {
+    async submit() {
       this.$refs.userForm.validate();
       if (this.isValid) {
         let promise = null;
@@ -131,13 +131,11 @@ export default {
         } else {
           promise = this.create(this.newUser);
         }
-        promise.then((succeeded) => {
-          if (succeeded) {
-            this.$router.push(
-              this.$route.query.redirect || { name: this.redirectFallback }
-            );
-          }
-        });
+        const succeeded = await promise;
+        if (succeeded)
+          this.$router.push(
+            this.$route.query.redirect || { name: this.redirectFallback }
+          );
       }
     },
   },

--- a/src/components/UserForm.vue
+++ b/src/components/UserForm.vue
@@ -132,10 +132,11 @@ export default {
           promise = this.create(this.newUser);
         }
         const succeeded = await promise;
-        if (succeeded)
+        if (succeeded) {
           this.$router.push(
             this.$route.query.redirect || { name: this.redirectFallback }
           );
+        }
       }
     },
   },

--- a/src/components/UserForm.vue
+++ b/src/components/UserForm.vue
@@ -125,13 +125,16 @@ export default {
     async submit() {
       this.$refs.userForm.validate();
       if (this.isValid) {
-        let promise = null;
+        let pendingResult = null;
         if (this.user) {
-          promise = this.update({ id: this.user.id, newUser: this.newUser });
+          pendingResult = this.update({
+            id: this.user.id,
+            newUser: this.newUser,
+          });
         } else {
-          promise = this.create(this.newUser);
+          pendingResult = this.create(this.newUser);
         }
-        const succeeded = await promise;
+        const succeeded = await pendingResult;
         if (succeeded) {
           this.$router.push(
             this.$route.query.redirect || { name: this.redirectFallback }

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -219,8 +219,11 @@ export default {
         promises.push(this.$store.dispatch("imageTypes/index"));
         promises.push(this.$store.dispatch("locations/index"));
       }
-      await Promise.all(promises);
-      this.loading = false;
+      try {
+        await Promise.all(promises);
+      } finally {
+        this.loading = false;
+      }
     },
     async logout() {
       await this.$store.dispatch("auth/logout");

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -200,36 +200,31 @@ export default {
     ...mapState("userSettings", ["locale"]),
   },
   methods: {
-    loadData() {
+    async loadData() {
       this.loading = true;
-      Promise.all([
-        this.$store.dispatch("auth/index"),
-        this.$store.dispatch("albums/index"),
-        this.$store.dispatch("artists/index"),
-        this.$store.dispatch("genres/index"),
-        this.$store.dispatch("labels/index"),
-        this.$store.dispatch("tracks/index"),
-        this.$store.dispatch("users/index").then(() => {
-          const promises = [];
-          if (this.isModerator) {
-            promises.push(this.$store.dispatch("rescan/show"));
-            promises.push(this.$store.dispatch("codecs/index"));
-            promises.push(this.$store.dispatch("codecConversions/index"));
-            promises.push(this.$store.dispatch("coverFilenames/index"));
-            promises.push(this.$store.dispatch("imageTypes/index"));
-            promises.push(this.$store.dispatch("locations/index"));
-          }
-          return Promise.all(promises);
-        }),
-        new Promise((resolve) => setTimeout(resolve, 1000)),
-      ]).finally(() => {
-        this.loading = false;
-      });
+      const auth = this.$store.dispatch("auth/index");
+      const albums = this.$store.dispatch("albums/index");
+      const artists = this.$store.dispatch("artists/index");
+      const genres = this.$store.dispatch("genres/index");
+      const labels = this.$store.dispatch("labels/index");
+      const tracks = this.$store.dispatch("tracks/index");
+      const users = this.$store.dispatch("users/index");
+      const promises = [auth, albums, artists, genres, labels, tracks, users];
+      await users;
+      if (this.isModerator) {
+        promises.push(this.$store.dispatch("rescan/show"));
+        promises.push(this.$store.dispatch("codecs/index"));
+        promises.push(this.$store.dispatch("codecConversions/index"));
+        promises.push(this.$store.dispatch("coverFilenames/index"));
+        promises.push(this.$store.dispatch("imageTypes/index"));
+        promises.push(this.$store.dispatch("locations/index"));
+      }
+      await Promise.all(promises);
+      this.loading = false;
     },
-    logout: function () {
-      this.$store.dispatch("auth/logout").then(() => {
-        this.$router.push({ name: "login" });
-      });
+    async logout() {
+      await this.$store.dispatch("auth/logout");
+      this.$router.push({ name: "login" });
     },
   },
 };

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -209,18 +209,26 @@ export default {
       const labels = this.$store.dispatch("labels/index");
       const tracks = this.$store.dispatch("tracks/index");
       const users = this.$store.dispatch("users/index");
-      const promises = [auth, albums, artists, genres, labels, tracks, users];
+      const pendingResults = [
+        auth,
+        albums,
+        artists,
+        genres,
+        labels,
+        tracks,
+        users,
+      ];
       await users;
       if (this.isModerator) {
-        promises.push(this.$store.dispatch("rescan/show"));
-        promises.push(this.$store.dispatch("codecs/index"));
-        promises.push(this.$store.dispatch("codecConversions/index"));
-        promises.push(this.$store.dispatch("coverFilenames/index"));
-        promises.push(this.$store.dispatch("imageTypes/index"));
-        promises.push(this.$store.dispatch("locations/index"));
+        pendingResults.push(this.$store.dispatch("rescan/show"));
+        pendingResults.push(this.$store.dispatch("codecs/index"));
+        pendingResults.push(this.$store.dispatch("codecConversions/index"));
+        pendingResults.push(this.$store.dispatch("coverFilenames/index"));
+        pendingResults.push(this.$store.dispatch("imageTypes/index"));
+        pendingResults.push(this.$store.dispatch("locations/index"));
       }
       try {
-        await Promise.all(promises);
+        await Promise.all(pendingResults);
       } finally {
         this.loading = false;
       }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -57,16 +57,13 @@ export default {
   methods: {
     ...mapActions("auth", ["login"]),
     ...mapMutations(["clearErrors"]),
-    submit: function () {
+    async submit() {
       this.clearErrors();
-      this.login({
+      const succeeded = await this.login({
         name: this.name,
         password: this.password,
-      }).then((succeeded) => {
-        if (succeeded) {
-          this.redirect();
-        }
       });
+      if (succeeded) this.redirect();
     },
     redirect: function () {
       const path = this.$route.query.redirect || "/app/";

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -63,7 +63,9 @@ export default {
         name: this.name,
         password: this.password,
       });
-      if (succeeded) this.redirect();
+      if (succeeded) {
+        this.redirect();
+      }
     },
     redirect: function () {
       const path = this.$route.query.redirect || "/app/";

--- a/src/views/genres/EditGenre.vue
+++ b/src/views/genres/EditGenre.vue
@@ -60,14 +60,11 @@ export default {
     fillValues() {
       this.newGenre.name = this.genre.name;
     },
-    submit() {
-      this.update({ id: this.genre.id, newGenre: this.newGenre }).then(
-        (succeeded) => {
-          if (succeeded) {
-            this.$router.push(this.$route.query.redirect || { name: "genres" });
-          }
-        }
-      );
+    async submit() {
+      const newGenre = { id: this.genre.id, newGenre: this.newGenre };
+      const succeeded = await this.update(newGenre);
+      if (succeeded)
+        this.$router.push(this.$route.query.redirect || { name: "genres" });
     },
   },
 };

--- a/src/views/genres/EditGenre.vue
+++ b/src/views/genres/EditGenre.vue
@@ -61,8 +61,10 @@ export default {
       this.newGenre.name = this.genre.name;
     },
     async submit() {
-      const newGenre = { id: this.genre.id, newGenre: this.newGenre };
-      const succeeded = await this.update(newGenre);
+      const succeeded = await this.update({
+        id: this.genre.id,
+        newGenre: this.newGenre,
+      });
       if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "genres" });
       }

--- a/src/views/genres/EditGenre.vue
+++ b/src/views/genres/EditGenre.vue
@@ -63,8 +63,9 @@ export default {
     async submit() {
       const newGenre = { id: this.genre.id, newGenre: this.newGenre };
       const succeeded = await this.update(newGenre);
-      if (succeeded)
+      if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "genres" });
+      }
     },
   },
 };

--- a/src/views/labels/EditLabel.vue
+++ b/src/views/labels/EditLabel.vue
@@ -63,8 +63,9 @@ export default {
     async submit() {
       const newLabel = { id: this.label.id, newLabel: this.newLabel };
       const succeeded = await this.update(newLabel);
-      if (succeeded)
+      if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "labels" });
+      }
     },
   },
 };

--- a/src/views/labels/EditLabel.vue
+++ b/src/views/labels/EditLabel.vue
@@ -60,14 +60,11 @@ export default {
     fillValues() {
       this.newLabel.name = this.label.name;
     },
-    submit() {
-      this.update({ id: this.label.id, newLabel: this.newLabel }).then(
-        (succeeded) => {
-          if (succeeded) {
-            this.$router.push(this.$route.query.redirect || { name: "labels" });
-          }
-        }
-      );
+    async submit() {
+      const newLabel = { id: this.label.id, newLabel: this.newLabel };
+      const succeeded = await this.update(newLabel);
+      if (succeeded)
+        this.$router.push(this.$route.query.redirect || { name: "labels" });
     },
   },
 };

--- a/src/views/labels/EditLabel.vue
+++ b/src/views/labels/EditLabel.vue
@@ -61,8 +61,10 @@ export default {
       this.newLabel.name = this.label.name;
     },
     async submit() {
-      const newLabel = { id: this.label.id, newLabel: this.newLabel };
-      const succeeded = await this.update(newLabel);
+      const succeeded = await this.update({
+        id: this.label.id,
+        newLabel: this.newLabel,
+      });
       if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "labels" });
       }

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -358,8 +358,10 @@ export default {
       });
 
       await Promise.all([...genre_map, ...artist_map]);
-      const newTrack = { id: this.track.id, newTrack: transformed };
-      const succeeded = await this.update(newTrack);
+      const succeeded = await this.update({
+        id: this.track.id,
+        newTrack: transformed,
+      });
       if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "tracks" });
       }

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -318,7 +318,7 @@ export default {
         track_artists: [],
       };
 
-      const genre_map = this.newTrack.genre_ids.map(async (genre_id) => {
+      const mappedGenres = this.newTrack.genre_ids.map(async (genre_id) => {
         if (typeof genre_id === "string") {
           const id = await this.createGenre({ name: genre_id });
           if (id) {
@@ -331,33 +331,35 @@ export default {
         }
       });
 
-      const artist_map = this.newTrack.track_artists.map(async (ta, index) => {
-        if (typeof ta.artist_id === "string") {
-          const id = await this.createArtist({
-            name: ta.artist_id,
-            review_comment: "New artist",
-          });
-          if (id) {
+      const mappedArtists = this.newTrack.track_artists.map(
+        async (ta, index) => {
+          if (typeof ta.artist_id === "string") {
+            const id = await this.createArtist({
+              name: ta.artist_id,
+              review_comment: "New artist",
+            });
+            if (id) {
+              transformed.track_artists.push({
+                artist_id: id,
+                name: ta.name || ta.artist_id,
+                role: ta.role,
+                order: index + 1,
+              });
+            } else {
+              throw false;
+            }
+          } else {
             transformed.track_artists.push({
-              artist_id: id,
-              name: ta.name || ta.artist_id,
+              artist_id: ta.artist_id.id,
+              name: ta.name || ta.artist_id.name,
               role: ta.role,
               order: index + 1,
             });
-          } else {
-            throw false;
           }
-        } else {
-          transformed.track_artists.push({
-            artist_id: ta.artist_id.id,
-            name: ta.name || ta.artist_id.name,
-            role: ta.role,
-            order: index + 1,
-          });
         }
-      });
+      );
 
-      await Promise.all([...genre_map, ...artist_map]);
+      await Promise.all([...mappedGenres, ...mappedArtists]);
       const succeeded = await this.update({
         id: this.track.id,
         newTrack: transformed,

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -306,7 +306,7 @@ export default {
         this.newTrack.track_artists.splice(index, 1)[0]
       );
     },
-    submit() {
+    async submit() {
       const transformed = {
         number: this.newTrack.number,
         title: this.newTrack.title,
@@ -317,43 +317,36 @@ export default {
         genre_ids: [],
         track_artists: [],
       };
-      const promises = [];
 
-      for (let genre_id of this.newTrack.genre_ids) {
+      const genre_map = this.newTrack.genre_ids.map(async (genre_id) => {
         if (typeof genre_id === "string") {
-          promises.push(
-            this.createGenre({ name: genre_id }).then((id) => {
-              if (id) {
-                transformed.genre_ids.push(id);
-              } else {
-                return Promise.reject();
-              }
-            })
-          );
+          const id = await this.createGenre({ name: genre_id });
+          if (id) {
+            transformed.genre_ids.push(id);
+          } else {
+            throw false;
+          }
         } else {
           transformed.genre_ids.push(genre_id.id);
         }
-      }
+      });
 
-      this.newTrack.track_artists.forEach((ta, index) => {
+      const artist_map = this.newTrack.track_artists.map(async (ta, index) => {
         if (typeof ta.artist_id === "string") {
-          promises.push(
-            this.createArtist({
-              name: ta.artist_id,
-              review_comment: "New artist",
-            }).then((id) => {
-              if (id) {
-                transformed.track_artists.push({
-                  artist_id: id,
-                  name: ta.name || ta.artist_id,
-                  role: ta.role,
-                  order: index + 1,
-                });
-              } else {
-                return Promise.reject();
-              }
-            })
-          );
+          const id = await this.createArtist({
+            name: ta.artist_id,
+            review_comment: "New artist",
+          });
+          if (id) {
+            transformed.track_artists.push({
+              artist_id: id,
+              name: ta.name || ta.artist_id,
+              role: ta.role,
+              order: index + 1,
+            });
+          } else {
+            throw false;
+          }
         } else {
           transformed.track_artists.push({
             artist_id: ta.artist_id.id,
@@ -364,17 +357,11 @@ export default {
         }
       });
 
-      Promise.all(promises).then(() => {
-        this.update({ id: this.track.id, newTrack: transformed }).then(
-          (succeeded) => {
-            if (succeeded) {
-              this.$router.push(
-                this.$route.query.redirect || { name: "tracks" }
-              );
-            }
-          }
-        );
-      });
+      await Promise.all([...genre_map, ...artist_map]);
+      const newTrack = { id: this.track.id, newTrack: transformed };
+      const succeeded = await this.update(newTrack);
+      if (succeeded)
+        this.$router.push(this.$route.query.redirect || { name: "tracks" });
     },
   },
 };

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -360,8 +360,9 @@ export default {
       await Promise.all([...genre_map, ...artist_map]);
       const newTrack = { id: this.track.id, newTrack: transformed };
       const succeeded = await this.update(newTrack);
-      if (succeeded)
+      if (succeeded) {
         this.$router.push(this.$route.query.redirect || { name: "tracks" });
+      }
     },
   },
 };


### PR DESCRIPTION
re #279 
See #286 for the same syntax switch in the store and API calls.

This PR switches to async/await syntax inside methods (computed and watched properties do not support this syntax).

There are some places where I've used `throw false`, as a replacement for `Promise.reject()`. We could throw any value to get the same result (but have to use *some* value), `false` made the most sense to me.