### PR TITLE
Evaluate isModerator at highest possible level

### DIFF
--- a/src/components/AlbumActions.vue
+++ b/src/components/AlbumActions.vue
@@ -38,7 +38,7 @@
       <span>{{ $t("music.album.no-tracks-to-add") }}</span>
     </VTooltip>
     <EditReviewComment :item="album" :update="flag" />
-    <VTooltip bottom :disabled="!waitingForReload">
+    <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
       <template v-slot:activator="{ on }">
         <span v-on="on">
           <VBtn
@@ -47,7 +47,6 @@
               params: { id: album.id },
               query: { redirect: $route.fullPath },
             }"
-            v-if="isModerator"
             :disabled="waitingForReload"
             color="edit"
             class="ma-2"
@@ -61,12 +60,11 @@
       </template>
       <span>{{ $t("common.disabled-while-loading") }}</span>
     </VTooltip>
-    <VTooltip bottom :disabled="!waitingForReload">
+    <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
       <template v-slot:activator="{ on }">
         <span v-on="on">
           <VBtn
             @click.stop.prevent="deleteAlbum"
-            v-if="isModerator"
             :disabled="album.loaded < startLoading"
             color="danger"
             class="ma-2"

--- a/src/components/ArtistActions.vue
+++ b/src/components/ArtistActions.vue
@@ -1,7 +1,7 @@
 <template>
   <span>
     <EditReviewComment :item="artist" :update="flag" />
-    <VTooltip bottom :disabled="!waitingForReload">
+    <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
       <template v-slot:activator="{ on }">
         <span v-on="on">
           <VBtn
@@ -10,7 +10,6 @@
               params: { id: artist.id },
               query: { redirect: $route.fullPath },
             }"
-            v-if="isModerator"
             :disabled="waitingForReload"
             color="edit"
             class="ma-2"
@@ -24,7 +23,7 @@
       </template>
       <span>{{ $t("common.disabled-while-loading") }}</span>
     </VTooltip>
-    <VTooltip bottom :disabled="!waitingForReload">
+    <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
       <template v-slot:activator="{ on }">
         <span v-on="on">
           <ArtistMergeDialog :artist="artist" :disabled="waitingForReload" />
@@ -32,12 +31,11 @@
       </template>
       <span>{{ $t("common.disabled-while-loading") }}</span>
     </VTooltip>
-    <VTooltip bottom :disabled="!waitingForReload">
+    <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
       <template v-slot:activator="{ on }">
         <span v-on="on">
           <VBtn
             @click.stop.prevent="deleteArtist"
-            v-if="isModerator"
             :disabled="waitingForReload"
             color="danger"
             class="ma-2"

--- a/src/components/GenreActions.vue
+++ b/src/components/GenreActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <span>
+  <span v-if="isModerator">
     <VTooltip bottom :disabled="!waitingForReload">
       <template v-slot:activator="{ on }">
         <span v-on="on">
@@ -9,7 +9,6 @@
               params: { id: genre.id },
               query: { redirect: $route.fullPath },
             }"
-            v-if="isModerator"
             :disabled="waitingForReload"
             color="edit"
             class="ma-2"
@@ -36,7 +35,6 @@
         <span v-on="on">
           <VBtn
             @click.stop.prevent="deleteGenre"
-            v-if="isModerator"
             :disabled="waitingForReload"
             color="danger"
             class="ma-2"

--- a/src/components/LabelActions.vue
+++ b/src/components/LabelActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <span>
+  <span v-if="isModerator">
     <VTooltip bottom :disabled="!waitingForReload">
       <template v-slot:activator="{ on }">
         <span v-on="on">
@@ -9,7 +9,6 @@
               params: { id: label.id },
               query: { redirect: $route.fullPath },
             }"
-            v-if="isModerator"
             :disabled="waitingForReload"
             color="edit"
             class="ma-2"
@@ -36,7 +35,6 @@
         <span v-on="on">
           <VBtn
             @click.stop.prevent="deleteLabel"
-            v-if="isModerator"
             :disabled="waitingForReload"
             color="danger"
             class="ma-2"


### PR DESCRIPTION
Small refactor in the `*Actions` components. I've moved the `v-if="isModerator" to the highest level possible.
In the current implementation we would still render the tooltip, but not render any activator.