### PR TITLE
Make albums sort more consistent

### DIFF
--- a/src/comparators.js
+++ b/src/comparators.js
@@ -10,7 +10,7 @@ export function compareStrings(s1, s2) {
 
 export function compareAlbumEditions(a1, a2) {
   // If one album has an edition but the other doesn't, we assume
-  // that the one without an edition is the "original" and schould come first.
+  // that the one without an edition is the "original" and should come first.
   if (a1.edition === null && a2.edition === null) {
     return 0;
   } else if (a1.edition === null) {

--- a/src/comparators.js
+++ b/src/comparators.js
@@ -38,18 +38,18 @@ export function compareTracks(rootState, t1, t2) {
     return -1;
   }
 
-  let albOrd = compareAlbumsByTitle(a1.normalized_title, a2.normalized_title);
+  let albOrd = compareAlbumsByTitleFirst(a1, a2);
   return albOrd === 0 ? t1.number - t2.number : albOrd;
 }
 
-export function compareAlbumsByTitle(a1, a2) {
+export function compareAlbumsByTitleFirst(a1, a2) {
   let order = compareStrings(a1.normalized_title, a2.normalized_title);
   order = order === 0 ? compareStrings(a1.release, a2.release) : order;
   order = order === 0 ? compareAlbumEditions(a1, a2) : order;
   return (order = order === 0 ? compareStrings(a1.id, a2.id) : order);
 }
 
-export function compareAlbumsByRelease(a1, a2) {
+export function compareAlbumsByReleaseFirst(a1, a2) {
   let order = compareStrings(a1.release, a2.release);
   order =
     order === 0

--- a/src/comparators.js
+++ b/src/comparators.js
@@ -8,6 +8,25 @@ export function compareStrings(s1, s2) {
   return 0;
 }
 
+export function compareAlbumEditions(a1, a2) {
+  // If one album has an edition but the other doesn't, we assume
+  // that the one without an edition is the "original" and schould come first.
+  if (a1.edition === null && a2.edition === null) {
+    return 0;
+  } else if (a1.edition === null) {
+    return -1;
+  } else if (a2.edition === null) {
+    return 1;
+  }
+
+  // If both have an edition, we sort by edition date first.
+  // If that is equal, we look to the description
+  let order = compareStrings(a1.edition, a2.edition);
+  return order === 0
+    ? compareStrings(a1.edition_description, a2.edition_description)
+    : order;
+}
+
 export function compareTracks(rootState, t1, t2) {
   const a1 = rootState.albums.albums[t1.album_id];
   const a2 = rootState.albums.albums[t2.album_id];
@@ -19,8 +38,23 @@ export function compareTracks(rootState, t1, t2) {
     return -1;
   }
 
-  let albOrd = compareStrings(a1.normalized_title, a2.normalized_title);
-  albOrd = albOrd === 0 ? compareStrings(a1.release, a2.release) : albOrd;
-  albOrd = albOrd === 0 ? compareStrings(a1.id, a2.id) : albOrd;
+  let albOrd = compareAlbumsByTitle(a1.normalized_title, a2.normalized_title);
   return albOrd === 0 ? t1.number - t2.number : albOrd;
+}
+
+export function compareAlbumsByTitle(a1, a2) {
+  let order = compareStrings(a1.normalized_title, a2.normalized_title);
+  order = order === 0 ? compareStrings(a1.release, a2.release) : order;
+  order = order === 0 ? compareAlbumEditions(a1, a2) : order;
+  return (order = order === 0 ? compareStrings(a1.id, a2.id) : order);
+}
+
+export function compareAlbumsByRelease(a1, a2) {
+  let order = compareStrings(a1.release, a2.release);
+  order =
+    order === 0
+      ? compareStrings(a1.normalized_title, a2.normalized_title)
+      : order;
+  order = order === 0 ? compareAlbumEditions(a1, a2) : order;
+  return (order = order === 0 ? compareStrings(a1.id, a2.id) : order);
 }

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -8,7 +8,10 @@ import {
   destroyEmpty,
 } from "../api/albums";
 import { fetchAll } from "./actions";
-import { compareAlbumsByRelease, compareAlbumsByTitle } from "../comparators";
+import {
+  compareAlbumsByReleaseFirst,
+  compareAlbumsByTitleFirst,
+} from "../comparators";
 
 export default {
   namespaced: true,
@@ -165,26 +168,22 @@ export default {
   getters: {
     albums: (state) => Object.values(state.albums),
     albumsByTitle: (state, getters) =>
-      getters.albums.sort((a1, a2) => compareAlbumsByTitle(a1, a2)),
+      getters.albums.sort(compareAlbumsByTitleFirst),
     albumsFilterByArtist: (state, getters) => (id) => {
       const aaFilter = (a) =>
         a.album_artists.filter((aa) => `${aa.artist_id}` === `${id}`).length >
         0;
-      return getters.albums
-        .filter(aaFilter)
-        .sort((a1, a2) => compareAlbumsByRelease(a1, a2));
+      return getters.albums.filter(aaFilter).sort(compareAlbumsByReleaseFirst);
     },
     albumsFilterByLabel: (state, getters) => (id) => {
       const alFilter = (a) =>
         a.album_labels.filter((l) => `${l.label_id}` === `${id}`).length > 0;
-      return getters.albums
-        .filter(alFilter)
-        .sort((a1, a2) => compareAlbumsByRelease(a1, a2));
+      return getters.albums.filter(alFilter).sort(compareAlbumsByReleaseFirst);
     },
     albumsFlagged: (state, getters) => {
       return getters.albums
         .filter((t) => t.review_comment !== null)
-        .sort((a1, a2) => compareAlbumsByTitle(a1, a2));
+        .sort(compareAlbumsByTitleFirst);
     },
     albumsOnThisDay: (state, getters, rootState) => {
       const today = new Date(rootState.currentDay);
@@ -195,7 +194,7 @@ export default {
               `${today.getMonth() + 1}`.padStart(2, "0") &&
             `${r.release.slice(-2)}` === `${today.getDate()}`.padStart(2, "0")
         )
-        .sort((a1, a2) => compareAlbumsByRelease(a1, a2));
+        .sort(compareAlbumsByReleaseFirst);
     },
   },
 };

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -8,7 +8,7 @@ import {
   destroyEmpty,
 } from "../api/albums";
 import { fetchAll } from "./actions";
-import { compareStrings } from "../comparators";
+import { compareAlbumsByRelease, compareAlbumsByTitle } from "../comparators";
 
 export default {
   namespaced: true,
@@ -165,38 +165,26 @@ export default {
   getters: {
     albums: (state) => Object.values(state.albums),
     albumsByTitle: (state, getters) =>
-      getters.albums.sort((a1, a2) =>
-        compareStrings(a1.normalized_title, a2.normalized_title)
-      ),
+      getters.albums.sort((a1, a2) => compareAlbumsByTitle(a1, a2)),
     albumsFilterByArtist: (state, getters) => (id) => {
       const aaFilter = (a) =>
         a.album_artists.filter((aa) => `${aa.artist_id}` === `${id}`).length >
         0;
       return getters.albums
         .filter(aaFilter)
-        .sort(
-          (a1, a2) =>
-            compareStrings(a1.release, a2.release) ||
-            compareStrings(a1.normalized_title, a2.normalized_title)
-        );
+        .sort((a1, a2) => compareAlbumsByRelease(a1, a2));
     },
     albumsFilterByLabel: (state, getters) => (id) => {
       const alFilter = (a) =>
         a.album_labels.filter((l) => `${l.label_id}` === `${id}`).length > 0;
       return getters.albums
         .filter(alFilter)
-        .sort(
-          (a1, a2) =>
-            compareStrings(a1.release, a2.release) ||
-            compareStrings(a1.normalized_title, a2.normalized_title)
-        );
+        .sort((a1, a2) => compareAlbumsByRelease(a1, a2));
     },
     albumsFlagged: (state, getters) => {
       return getters.albums
         .filter((t) => t.review_comment !== null)
-        .sort((a1, a2) =>
-          compareStrings(a1.normalized_title, a2.normalized_title)
-        );
+        .sort((a1, a2) => compareAlbumsByTitle(a1, a2));
     },
     albumsOnThisDay: (state, getters, rootState) => {
       const today = new Date(rootState.currentDay);
@@ -207,11 +195,7 @@ export default {
               `${today.getMonth() + 1}`.padStart(2, "0") &&
             `${r.release.slice(-2)}` === `${today.getDate()}`.padStart(2, "0")
         )
-        .sort(
-          (a1, a2) =>
-            compareStrings(a1.release, a2.release) ||
-            compareStrings(a1.normalized_title, a2.normalized_title)
-        );
+        .sort((a1, a2) => compareAlbumsByRelease(a1, a2));
     },
   },
 };


### PR DESCRIPTION
This PR does two things:
1. It provides a way to sort albums when `release` and/or `normalized_title` are equal.
In the current sorting, there were a few cases where we would still sort based on the orginal order (American Football's three s/t in when sorting by title, the two versions of Amenra's Mass VI when sorting by release or title).
If release and/or title don't result in an order, we look to the edition information (first the edition date and then the description). If that still doesn't provide an order, we look at the id to be sure we have a consistent order.

2. It  makes sorting albums more consistent.
in `compareTracks` we looked at `normalized_title`, `release` and `id`. If we sorted by title we usually only looked at the `normalized_title` and nothing else, while sorting by release also looked at `normalized_title`.
I've made two clear sorting orders (title first or release first) that both have enough fallback values so that we should always get the same order.