### PR TITLE
Don't convert response to json if status is 204

### DIFF
--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -47,7 +47,7 @@ async function resolveRequest(path, options) {
   } catch (reason) {
     throw { error: [reason] };
   }
-  const result = await response.json();
+  const result = response.status === 204 ? true : await response.json();
   if (response.ok) {
     return result;
   } else {


### PR DESCRIPTION
If we get status 204, we should not try to parse the body, since this will result in `Error JSON.parse: unexpected end of data at line 1 column 1 of the JSON data`. (Currently resulting in an empty VAlert for the user).