### PR TITLE
Add template for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+Thanks for contributing to Accentor!
+Make sure all GitHub actions (lint & build) will pass and fill out the template.
+
+You can tag your PR with the relevant tags and request a review from someone of the team.
+If any changes to your PR are necessary, we will ask for them through the review process.
+ -->
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
+
+Fix # (issue)
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B


### PR DESCRIPTION
fix #303 

I found some examples with [a checklist for requirements](https://github.com/vuetifyjs/vuetify/blob/master/.github/PULL_REQUEST_TEMPLATE.md), but felt this was a bit too much for now. (And we have GitHub actions to check whether the style guide is followed, asking a contributer to confirm this again is a bit belittling.)

As with the issue template, code of conduct, and contributing. I'll add this (in modified form) to the api repo and the android repo once this is merged.