### PR TITLE
Defer loading library data until library-page is loaded

### DIFF
--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -202,31 +202,14 @@ export default {
   methods: {
     async loadData() {
       this.loading = true;
-      const auth = this.$store.dispatch("auth/index");
-      const albums = this.$store.dispatch("albums/index");
-      const artists = this.$store.dispatch("artists/index");
-      const genres = this.$store.dispatch("genres/index");
-      const labels = this.$store.dispatch("labels/index");
-      const tracks = this.$store.dispatch("tracks/index");
-      const users = this.$store.dispatch("users/index");
-      const pendingResults = [
-        auth,
-        albums,
-        artists,
-        genres,
-        labels,
-        tracks,
-        users,
-      ];
-      await users;
-      if (this.isModerator) {
-        pendingResults.push(this.$store.dispatch("rescan/show"));
-        pendingResults.push(this.$store.dispatch("codecs/index"));
-        pendingResults.push(this.$store.dispatch("codecConversions/index"));
-        pendingResults.push(this.$store.dispatch("coverFilenames/index"));
-        pendingResults.push(this.$store.dispatch("imageTypes/index"));
-        pendingResults.push(this.$store.dispatch("locations/index"));
-      }
+      let pendingResults = [];
+      pendingResults.push(this.$store.dispatch("auth/index"));
+      pendingResults.push(this.$store.dispatch("albums/index"));
+      pendingResults.push(this.$store.dispatch("artists/index"));
+      pendingResults.push(this.$store.dispatch("genres/index"));
+      pendingResults.push(this.$store.dispatch("labels/index"));
+      pendingResults.push(this.$store.dispatch("tracks/index"));
+      pendingResults.push(this.$store.dispatch("users/index"));
       try {
         await Promise.all(pendingResults);
       } finally {

--- a/src/views/App.vue
+++ b/src/views/App.vue
@@ -187,8 +187,8 @@ export default {
     locale() {
       this.$i18n.locale = this.locale;
     },
-    finishedAt() {
-      if (!this.loading) {
+    finishedAt(newValue, oldValue) {
+      if (!this.loading && typeof oldValue !== "undefined") {
         this.loadData();
       }
     },

--- a/src/views/Library.vue
+++ b/src/views/Library.vue
@@ -114,6 +114,9 @@ export default {
     EditLocations,
     MaintenanceActions,
   },
+  created() {
+    this.loadData();
+  },
   computed: {
     ...mapGetters("auth", ["isModerator"]),
     ...mapState("rescan", ["rescan"]),
@@ -127,6 +130,18 @@ export default {
   },
   methods: {
     ...mapActions("rescan", ["start"]),
+    async loadData() {
+      let pendingResults = [];
+      if (this.isModerator) {
+        pendingResults.push(this.$store.dispatch("rescan/show"));
+        pendingResults.push(this.$store.dispatch("codecs/index"));
+        pendingResults.push(this.$store.dispatch("codecConversions/index"));
+        pendingResults.push(this.$store.dispatch("coverFilenames/index"));
+        pendingResults.push(this.$store.dispatch("imageTypes/index"));
+        pendingResults.push(this.$store.dispatch("locations/index"));
+      }
+      await Promise.all(pendingResults);
+    },
   },
 };
 </script>


### PR DESCRIPTION
This PR changes the way we load the initial data.
I've removed all moderator only data in `App.vue` and moved this to the library page.

## Why?
Loading the library-data on the initial load creates a lot of requests to the server, which seems to make the repsonse to requests slower. Since we don't need the library data for the app to function, we can defer loading these until the mod/admin actually goes to the library-page. 
This also makes that data on the library page has a higher chance of being up to date when a mod/admin wants to edit something.
