### PR TITLE
Wait for index to load before finishing destroyEmpty

### DIFF
--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -157,7 +157,7 @@ export default {
     async destroyEmpty({ commit, dispatch, rootState }) {
       try {
         await destroyEmpty(rootState.auth);
-        dispatch("index");
+        await dispatch("index");
         return true;
       } catch (error) {
         commit("addError", error, { root: true });

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -109,7 +109,7 @@ export default {
     async destroyEmpty({ commit, dispatch, rootState }) {
       try {
         await destroyEmpty(rootState.auth);
-        dispatch("index");
+        await dispatch("index");
         return true;
       } catch (error) {
         commit("addError", error, { root: true });

--- a/src/store/genres.js
+++ b/src/store/genres.js
@@ -108,7 +108,7 @@ export default {
     async destroyEmpty({ commit, dispatch, rootState }) {
       try {
         await destroyEmpty(rootState.auth);
-        dispatch("index");
+        await dispatch("index");
         return true;
       } catch (error) {
         commit("addError", error, { root: true });

--- a/src/store/labels.js
+++ b/src/store/labels.js
@@ -108,7 +108,7 @@ export default {
     async destroyEmpty({ commit, dispatch, rootState }) {
       try {
         await destroyEmpty(rootState.auth);
-        dispatch("index");
+        await dispatch("index");
         return true;
       } catch (error) {
         commit("addError", error, { root: true });


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

## Description

This PR fixes a small bug from #286 : We no longer waited for the index to finish loading, before returning true to the component.
We now await the index action before returning something to the component calling the action

# How Has This Been Tested?

Quick local test to see if button stayed disabled for the appropriate amount
