### PR TITLE
Move TrackArtists field to separate component

### DIFF
--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -228,60 +228,10 @@
                   />
                 </VCol>
               </VRow>
-              <VRow
-                :key="index"
-                v-for="(item, index) of changeArtists.track_artists"
-                no-gutters
-              >
-                <VCol
-                  class="flex-column flex-grow-0"
-                  v-if="changeArtists.enabled"
-                >
-                  <VBtn
-                    @click="moveArtist(index, -1)"
-                    icon
-                    small
-                    class="ma-2"
-                    :disabled="index === 0"
-                  >
-                    <VIcon>mdi-menu-up</VIcon>
-                  </VBtn>
-                  <VBtn
-                    @click="moveArtist(index, 1)"
-                    icon
-                    small
-                    class="ma-2"
-                    :disabled="index === changeArtists.track_artists.length - 1"
-                  >
-                    <VIcon>mdi-menu-down</VIcon>
-                  </VBtn>
-                  <VBtn @click="removeArtist(index)" icon small class="ma-2">
-                    <VIcon>mdi-close</VIcon>
-                  </VBtn>
-                </VCol>
-                <VCol v-if="changeArtists.enabled">
-                  <VCombobox
-                    :items="sortedArtists"
-                    :filter="filterName"
-                    item-text="name"
-                    item-value="id"
-                    :label="$tc('music.artists', 2)"
-                    :rules="rules.artist"
-                    return-object
-                    v-model="item.artist_id"
-                  />
-                  <VTextField :label="$t('common.name')" v-model="item.name" />
-                  <VAutocomplete
-                    :items="roles"
-                    :label="$t('music.artist.role')"
-                    v-model="item.role"
-                  />
-                  <VDivider
-                    light
-                    v-if="index !== changeArtists.track_artists.length - 1"
-                  />
-                </VCol>
-              </VRow>
+              <TrackFormArtists
+                v-model="changeArtists.track_artists"
+                v-if="changeArtists.enabled"
+              />
               <VBtn
                 @click="addArtist"
                 color="success"
@@ -326,46 +276,17 @@
 <script>
 import { mapActions, mapGetters, mapState } from "vuex";
 import Errors from "./Errors";
+import TrackFormArtists from "./TrackFormArtists.vue";
 
 export default {
   name: "MassEditDialog",
-  components: { Errors },
+  components: { Errors, TrackFormArtists },
   props: {
     tracks: { default: () => [], type: Array },
   },
   data() {
     return {
       dialog: false,
-      roles: [
-        {
-          value: "main",
-          text: this.$t("music.artist.roles.main"),
-        },
-        {
-          value: "performer",
-          text: this.$t("music.artist.roles.performer"),
-        },
-        {
-          value: "composer",
-          text: this.$t("music.artist.roles.composer"),
-        },
-        {
-          value: "conductor",
-          text: this.$t("music.artist.roles.conductor"),
-        },
-        {
-          value: "remixer",
-          text: this.$t("music.artist.roles.remixer"),
-        },
-        {
-          value: "producer",
-          text: this.$t("music.artist.roles.producer"),
-        },
-        {
-          value: "arranger",
-          text: this.$t("music.artist.roles.arranger"),
-        },
-      ],
       titleReplacement: {
         enabled: false,
         search: "",
@@ -409,9 +330,6 @@ export default {
     ...mapGetters("albums", {
       sortedAlbums: "albumsByTitle",
     }),
-    ...mapGetters("artists", {
-      sortedArtists: "artistsByName",
-    }),
     ...mapGetters("genres", {
       sortedGenres: "genresByName",
     }),
@@ -442,12 +360,6 @@ export default {
       };
       if (this.changeGenres.enabled) {
         rules.genre.push(genreValidation);
-      }
-
-      if (this.changeArtists.enabled) {
-        const artistValidation = (v) =>
-          !!v || this.$t("errors.artists.artist-blank");
-        rules.artist.push(artistValidation);
       }
 
       if (this.album.enabled) {
@@ -616,16 +528,6 @@ export default {
         name: "",
         role: "main",
       });
-    },
-    removeArtist(index) {
-      this.changeArtists.track_artists.splice(index, 1);
-    },
-    moveArtist(index, direction) {
-      this.changeArtists.track_artists.splice(
-        index + direction,
-        0,
-        this.changeArtists.track_artists.splice(index, 1)[0]
-      );
     },
     resetState() {
       this.titleReplacement = {

--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -93,12 +93,15 @@ export default {
       required: true,
     },
   },
-  mounted() {
-    this.trackArtists = this.value;
-  },
   watch: {
     trackArtists(newValue) {
       this.$emit("update:value", newValue);
+    },
+    value: {
+      handler() {
+        this.trackArtists = this.value;
+      },
+      immediate: true,
     },
   },
   computed: {

--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -1,0 +1,134 @@
+<template>
+  <div>
+    <VRow :key="index" v-for="(item, index) of trackArtists" no-gutters>
+      <VCol class="flex-column flex-grow-0">
+        <VBtn
+          @click="moveArtist(index, -1)"
+          icon
+          small
+          class="ma-2"
+          :disabled="index === 0"
+        >
+          <VIcon>mdi-menu-up</VIcon>
+        </VBtn>
+        <VBtn
+          @click="moveArtist(index, 1)"
+          icon
+          small
+          class="ma-2"
+          :disabled="index === trackArtists.length - 1"
+        >
+          <VIcon>mdi-menu-down</VIcon>
+        </VBtn>
+        <VBtn @click="removeArtist(index)" icon small class="ma-2">
+          <VIcon>mdi-close</VIcon>
+        </VBtn>
+      </VCol>
+      <VCol>
+        <VCombobox
+          :items="sortedArtists"
+          :filter="filterName"
+          item-text="name"
+          item-value="id"
+          :label="$tc('music.artists', 2)"
+          :rules="rules"
+          return-object
+          v-model="item.artist_id"
+        />
+        <VTextField :label="$t('common.name')" v-model="item.name" />
+        <VAutocomplete
+          :items="roles"
+          :label="$t('music.artist.role')"
+          v-model="item.role"
+        />
+        <VDivider light v-if="index !== trackArtists.length - 1" />
+      </VCol>
+    </VRow>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from "vuex";
+
+export default {
+  name: "TrackFormArtists",
+  data() {
+    return {
+      roles: [
+        {
+          value: "main",
+          text: this.$t("music.artist.roles.main"),
+        },
+        {
+          value: "performer",
+          text: this.$t("music.artist.roles.performer"),
+        },
+        {
+          value: "composer",
+          text: this.$t("music.artist.roles.composer"),
+        },
+        {
+          value: "conductor",
+          text: this.$t("music.artist.roles.conductor"),
+        },
+        {
+          value: "remixer",
+          text: this.$t("music.artist.roles.remixer"),
+        },
+        {
+          value: "producer",
+          text: this.$t("music.artist.roles.producer"),
+        },
+        {
+          value: "arranger",
+          text: this.$t("music.artist.roles.arranger"),
+        },
+      ],
+      trackArtists: [],
+    };
+  },
+  props: {
+    value: {
+      type: Array,
+      required: true,
+    },
+  },
+  mounted() {
+    this.trackArtists = this.value;
+  },
+  watch: {
+    trackArtists(newValue) {
+      this.$emit("update:value", newValue);
+    },
+  },
+  computed: {
+    ...mapGetters("artists", {
+      sortedArtists: "artistsByName",
+    }),
+    rules() {
+      const artistValidation = (v) =>
+        !!v || this.$t("errors.artists.artist-blank");
+      return [artistValidation];
+    },
+  },
+  methods: {
+    filterName(item, queryText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.name.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_name.indexOf(search) > -1
+      );
+    },
+    removeArtist(index) {
+      this.trackArtists.splice(index, 1);
+    },
+    moveArtist(index, direction) {
+      this.trackArtists.splice(
+        index + direction,
+        0,
+        this.trackArtists.splice(index, 1)[0]
+      );
+    },
+  },
+};
+</script>

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -50,7 +50,10 @@
             v-model="newTrack.genre_ids"
           />
           <h4 class="text-subtitle-1">{{ $tc("music.artists", 2) }}</h4>
-          <TrackFormArtists v-model="newTrack.track_artists" />
+          <TrackFormArtists
+            v-model="newTrack.track_artists"
+            @update:value.once="isDirty = true"
+          />
           <VCheckbox
             v-if="track.review_comment !== null"
             v-model="clear_review_comment"

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -50,61 +50,7 @@
             v-model="newTrack.genre_ids"
           />
           <h4 class="text-subtitle-1">{{ $tc("music.artists", 2) }}</h4>
-          <VRow
-            :key="index"
-            v-for="(item, index) of newTrack.track_artists"
-            no-gutters
-          >
-            <VCol class="flex-grow-0 flex-column">
-              <VBtn
-                @click="moveArtist(index, -1)"
-                @click.once="isDirty = true"
-                icon
-                small
-                class="ma-2"
-                :disabled="index === 0"
-              >
-                <VIcon>mdi-menu-up</VIcon>
-              </VBtn>
-              <VBtn
-                @click="moveArtist(index, 1)"
-                @click.once="isDirty = true"
-                icon
-                small
-                class="ma-2"
-                :disabled="index === newTrack.track_artists.length - 1"
-              >
-                <VIcon>mdi-menu-down</VIcon>
-              </VBtn>
-              <VBtn
-                @click="removeArtist(index)"
-                @click.once="isDirty = true"
-                icon
-                small
-                class="ma-2"
-              >
-                <VIcon>mdi-close</VIcon>
-              </VBtn>
-            </VCol>
-            <VCol>
-              <VCombobox
-                :items="sortedArtists"
-                :filter="filterName"
-                item-text="name"
-                item-value="id"
-                :label="$tc('music.artists', 1)"
-                return-object
-                v-model="item.artist_id"
-              />
-              <VTextField :label="$t('common.name')" v-model="item.name" />
-              <VAutocomplete
-                :items="roles"
-                :label="$t('music.artist.role')"
-                v-model="item.role"
-              />
-              <VDivider v-if="index !== newTrack.track_artists.length - 1" />
-            </VCol>
-          </VRow>
+          <TrackFormArtists v-model="newTrack.track_artists" />
           <VCheckbox
             v-if="track.review_comment !== null"
             v-model="clear_review_comment"
@@ -137,8 +83,10 @@
 
 <script>
 import { mapActions, mapGetters, mapState } from "vuex";
+import TrackFormArtists from "@/components/TrackFormArtists.vue";
 
 export default {
+  components: { TrackFormArtists },
   name: "EditTrack",
   data() {
     return {
@@ -150,36 +98,6 @@ export default {
         track_artists: [],
         genre_ids: [],
       },
-      roles: [
-        {
-          value: "main",
-          text: this.$t("music.artist.roles.main"),
-        },
-        {
-          value: "performer",
-          text: this.$t("music.artist.roles.performer"),
-        },
-        {
-          value: "composer",
-          text: this.$t("music.artist.roles.composer"),
-        },
-        {
-          value: "conductor",
-          text: this.$t("music.artist.roles.conductor"),
-        },
-        {
-          value: "remixer",
-          text: this.$t("music.artist.roles.remixer"),
-        },
-        {
-          value: "producer",
-          text: this.$t("music.artist.roles.producer"),
-        },
-        {
-          value: "arranger",
-          text: this.$t("music.artist.roles.arranger"),
-        },
-      ],
       clear_review_comment: true,
       isDirty: false,
       isValid: true,
@@ -294,16 +212,6 @@ export default {
         name: "",
         role: "main",
       });
-    },
-    removeArtist(index) {
-      this.newTrack.track_artists.splice(index, 1);
-    },
-    moveArtist(index, direction) {
-      this.newTrack.track_artists.splice(
-        index + direction,
-        0,
-        this.newTrack.track_artists.splice(index, 1)[0]
-      );
     },
     async submit() {
       const transformed = {


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

# Description

I wanted to change some other things about the TrackArtists fields (making them sortable by drag and drop), but felt it might be easier to do this once for both TrackEdit and MassEditDialog.

This PR contains the refactor, once this is merged another one will contain the enhacement.

# How Has This Been Tested?

Local tests to add new artist, remove artist, move artists around and make sure this updates correctly on submit

For:
- [X] EditTrack page
- [X] MasEditDialog component
