### PR TITLE
Prevent rescan show from starting multiple loops

### DIFF
--- a/src/store/rescan.js
+++ b/src/store/rescan.js
@@ -39,6 +39,7 @@ export default {
         return true;
       } catch (error) {
         commit("addError", error, { root: true });
+        commit("setLoading", false);
         return false;
       }
     },

--- a/src/store/rescan.js
+++ b/src/store/rescan.js
@@ -1,30 +1,41 @@
 import { show, start } from "../api/rescan";
+import { wait } from "../utils";
 
 export default {
   namespaced: true,
   state: {
     rescan: null,
     lastClick: new Date(0),
+    loading: false,
   },
   mutations: {
     setLastClick(state, payload) {
       state.lastClick = payload;
+    },
+    setLoading(state, payload) {
+      state.loading = payload;
     },
     setRescan(state, payload) {
       state.rescan = payload;
     },
   },
   actions: {
-    async show({ commit, dispatch, rootState }) {
+    async show({ commit, rootState }) {
+      if (rootState.rescan.loading) {
+        return true;
+      }
       try {
-        const result = await show(rootState.auth);
-        commit("setRescan", result);
-        if (
+        commit("setLoading", true);
+        let result = null;
+        do {
+          result = await show(rootState.auth);
+          commit("setRescan", result);
+          await wait(1000);
+        } while (
           rootState.rescan.lastClick > new Date(result.finished_at) ||
           result.running
-        ) {
-          setTimeout(() => dispatch("show"), 1000);
-        }
+        );
+        commit("setLoading", false);
         return true;
       } catch (error) {
         commit("addError", error, { root: true });

--- a/src/store/rescan.js
+++ b/src/store/rescan.js
@@ -1,5 +1,4 @@
 import { show, start } from "../api/rescan";
-import { wait } from "../utils";
 
 export default {
   namespaced: true,
@@ -30,7 +29,7 @@ export default {
         do {
           result = await show(rootState.auth);
           commit("setRescan", result);
-          await wait(1000);
+          await new Promise((resolve) => setTimeout(resolve, 1000));
         } while (
           rootState.rescan.lastClick > new Date(result.finished_at) ||
           result.running

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,3 @@
+export function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,0 @@
-export function wait(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

## Description

Fix #371
Changes the rescan show action so that it only resolves once the rescan is no longer running.
If show is triggered a second time we return true immediately.


# How Has This Been Tested?

Tested locally, both when rescan is running and when it isn't
