### PR TITLE
Improve reordering of TrackArtists

### DIFF
--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -11,7 +11,7 @@
           class="d-flex justify-space-between fill-height flex-column py-2"
         >
           <VBtn
-            @click="moveArtist({ oldIndex: index, newIndex: index - 1 })"
+            @click="moveArtist(index, -1)"
             icon
             small
             class="ma-2"
@@ -31,7 +31,7 @@
             <VIcon>mdi-drag-horizontal-variant</VIcon>
           </VBtn>
           <VBtn
-            @click="moveArtist({ oldIndex: index, newIndex: index + 1 })"
+            @click="moveArtist(index, 1)"
             icon
             small
             class="ma-2"

--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -20,7 +20,14 @@
           >
             <VIcon>mdi-menu-up</VIcon>
           </VBtn>
-          <VBtn small icon text class="ma-2 drag-handle" tabindex="-1">
+          <VBtn
+            small
+            icon
+            text
+            class="ma-2 drag-handle"
+            tabindex="-1"
+            :disabled="trackArtists.length === 1"
+          >
             <VIcon>mdi-drag-horizontal-variant</VIcon>
           </VBtn>
           <VBtn

--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -1,28 +1,48 @@
 <template>
-  <div>
+  <Draggable :list="this.trackArtists">
     <VRow :key="index" v-for="(item, index) of trackArtists" no-gutters>
       <VCol class="flex-column flex-grow-0">
-        <VBtn
-          @click="moveArtist(index, -1)"
-          icon
-          small
-          class="ma-2"
-          :disabled="index === 0"
+        <div
+          tabindex="0"
+          :data-index="index"
+          @keyup.delete="removeArtist(index)"
+          @keyup="handleKeyUp($event.key, index)"
+          :ref="index"
+          class="d-flex justify-space-between fill-height flex-column py-2"
         >
-          <VIcon>mdi-menu-up</VIcon>
-        </VBtn>
-        <VBtn
-          @click="moveArtist(index, 1)"
-          icon
-          small
-          class="ma-2"
-          :disabled="index === trackArtists.length - 1"
-        >
-          <VIcon>mdi-menu-down</VIcon>
-        </VBtn>
-        <VBtn @click="removeArtist(index)" icon small class="ma-2">
-          <VIcon>mdi-close</VIcon>
-        </VBtn>
+          <VBtn
+            @click="moveArtist({ oldIndex: index, newIndex: index - 1 })"
+            icon
+            small
+            class="ma-2"
+            :disabled="index === 0"
+            tabindex="-1"
+          >
+            <VIcon>mdi-menu-up</VIcon>
+          </VBtn>
+          <VBtn small icon text class="ma-2" tabindex="-1">
+            <VIcon>mdi-drag-horizontal-variant</VIcon>
+          </VBtn>
+          <VBtn
+            @click="moveArtist({ oldIndex: index, newIndex: index + 1 })"
+            icon
+            small
+            class="ma-2"
+            :disabled="index === trackArtists.length - 1"
+            tabindex="-1"
+          >
+            <VIcon>mdi-menu-down</VIcon>
+          </VBtn>
+          <VBtn
+            @click="removeArtist(index)"
+            icon
+            small
+            class="ma-2"
+            tabindex="-1"
+          >
+            <VIcon>mdi-close</VIcon>
+          </VBtn>
+        </div>
       </VCol>
       <VCol>
         <VCombobox
@@ -44,14 +64,18 @@
         <VDivider light v-if="index !== trackArtists.length - 1" />
       </VCol>
     </VRow>
-  </div>
+  </Draggable>
 </template>
 
 <script>
 import { mapGetters } from "vuex";
+import Draggable from "vuedraggable";
 
 export default {
   name: "TrackFormArtists",
+  components: {
+    Draggable,
+  },
   data() {
     return {
       roles: [
@@ -131,6 +155,19 @@ export default {
         0,
         this.trackArtists.splice(index, 1)[0]
       );
+    },
+    handleKeyUp(key, index) {
+      let direction;
+      if (key === "ArrowDown" || key === "d") {
+        direction = 1;
+      } else if (key === "ArrowUp" || key === "u") {
+        direction = -1;
+      }
+      if (typeof direction !== "undefined") {
+        this.moveArtist(index, direction);
+        // Due to the way Vue updates the DOM, we have to manually focus on the current trackArtist in its new place
+        this.$refs[index + direction][0].focus();
+      }
     },
   },
 };

--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -1,5 +1,5 @@
 <template>
-  <Draggable :list="this.trackArtists">
+  <Draggable :list="this.trackArtists" handle=".drag-handle">
     <VRow :key="index" v-for="(item, index) of trackArtists" no-gutters>
       <VCol class="flex-column flex-grow-0">
         <div
@@ -20,7 +20,7 @@
           >
             <VIcon>mdi-menu-up</VIcon>
           </VBtn>
-          <VBtn small icon text class="ma-2" tabindex="-1">
+          <VBtn small icon text class="ma-2 drag-handle" tabindex="-1">
             <VIcon>mdi-drag-horizontal-variant</VIcon>
           </VBtn>
           <VBtn

--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -170,7 +170,11 @@ export default {
       } else if (key === "ArrowUp" || key === "u") {
         direction = -1;
       }
-      if (typeof direction !== "undefined") {
+      if (
+        typeof direction !== "undefined" &&
+        index + direction >= 0 &&
+        index + direction < this.trackArtists.length
+      ) {
         this.moveArtist(index, direction);
         // Due to the way Vue updates the DOM, we have to manually focus on the current trackArtist in its new place
         this.$refs[index + direction][0].focus();

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -9,7 +9,7 @@
         >
           {{ track.review_comment }}
         </VAlert>
-        <VForm v-model="isValid" @submit.prevent="submit">
+        <VForm v-model="isValid" @submit.prevent="submit" v-if="loaded">
           <VTextField
             type="number"
             :label="$t('music.track.number')"
@@ -104,17 +104,20 @@ export default {
       clear_review_comment: true,
       isDirty: false,
       isValid: true,
+      loaded: false,
     };
   },
   async created() {
     if (this.track) {
       await this.read(this.track.id);
+      this.loaded = true;
       this.fillValues();
     }
   },
   watch: {
     track: function () {
       if (this.track && !this.isDirty) {
+        this.loaded = true;
         this.fillValues();
       }
     },


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

# Description

This PR brings two improvements to the way TrackArtists can be ordered.

## Drag and drop
I've added drag and drop support, so the user can quickly move an artist multiple steps (Especially relevent for tracks with many artists).
This only works through the drag-icon and is disabled if the length of TrackArtists is exactly one.

## Keypress controls
Currently the user has to tab multiple times to go past the controls (something which annoys me a lot).
To improve the UX if created one element around all the buttons with a few keypress events to control teh order.
A user can move the artist with ArrowUp, ArrowDown and U (for up) and D (for down).
A user can delete the artist through delete or backspace.

This does mean that there is no way to focus on the individual buttons. If this is necessary (but IMHO it isn't) we could allow the user to enter this level by pressing enter (and esc to leave).

(Do note that there is no way for a new user to know these things. I like the way how Hey gives this information, but this wouldn't fit our current UI.)

## Other small improvements
* Better spacing for order controls
* The EditTrack form is only shown after the track is loaded, to prevent a quick flash of the form in its empty state before the track is loaded 

# How Has This Been Tested?

Tested in chrome 87 and FF 83 on macOS, both for EditTrack page and MassEditDialog component
