### PR TITLE
Fix order of artists through mass edit

### DIFF
--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -491,7 +491,7 @@ export default {
                     ta.artist_id === a.artist_id
                 ).length === 0
               ) {
-                a.order += t.track_artists.length - 1;
+                a.order += t.track_artists.length;
                 transformed.track_artists.push(a);
               }
             });

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -457,7 +457,7 @@ export default {
           album_id: t.album_id,
           review_comment: this.clearReviewComments ? null : t.review_comment,
           genre_ids: t.genre_ids,
-          track_artists: t.track_artists,
+          track_artists: [...t.track_artists],
         };
 
         if (this.number.enabled) {

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -456,7 +456,7 @@ export default {
           title: t.title,
           album_id: t.album_id,
           review_comment: this.clearReviewComments ? null : t.review_comment,
-          genre_ids: t.genre_ids,
+          genre_ids: [...t.genre_ids],
           track_artists: [...t.track_artists],
         };
 


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

## Description

Fix #34 
We previously set the order of the artists in a track based on the length, which changed while we were adding the artists.
This would mess up the order if for some reason the transformedArtists array is not in the same order as the order property. (Which seems to happen with new artists)

We now set the order based on the length of the length before we start adding.
I've dropped the `-1` since this would generate orders like `1, 1, 2, 3`.

# How Has This Been Tested?

Tested locally with a number of tracks
