### PR TITLE
Allow user to sort TrackTable

### DIFF
--- a/src/comparators.js
+++ b/src/comparators.js
@@ -74,48 +74,46 @@ export function compareTracksByArtist(t1, t2) {
   return order;
 }
 
-export function compareTracksByGenre(
-  t1,
-  t2,
-  genres = store.state.genres.genres
-) {
-  // tracks without genres get sorted last
-  if (t1.genre_ids.length === 0 && t2.genre_ids.length === 0) {
-    return 0;
-  } else if (t1.genre_ids.length === 0) {
-    return 1;
-  } else if (t2.genre_ids.length === 0) {
-    return -1;
-  }
-
-  // we map the genres for each track and sort by name
-  const t1_genres = t1.genre_ids
-    .map((g) => genres[g].normalized_name)
-    .sort((g1, g2) => compareStrings(g1, g2));
-  const t2_genres = t2.genre_ids
-    .map((g) => genres[g].normalized_name)
-    .sort((g1, g2) => compareStrings(g1, g2));
-
-  // We loop over the sorted genres until we find a difference to sort by
-  let index = 0;
-  let order = 0;
-  while (order === 0) {
-    const g1 = t1_genres[index];
-    const g2 = t2_genres[index];
-
-    // If tracks share the same genres, but one track has one or more extra genre(s),
-    // we sort the track with more genres last
-    if (typeof g1 === "undefined" && typeof g2 === "undefined") {
+export function compareTracksByGenre(genres) {
+  return function (t1, t2) {
+    // tracks without genres get sorted last
+    if (t1.genre_ids.length === 0 && t2.genre_ids.length === 0) {
       return 0;
-    } else if (typeof g1 === "undefined") {
-      return -1;
-    } else if (typeof g2 === "undefined") {
+    } else if (t1.genre_ids.length === 0) {
       return 1;
+    } else if (t2.genre_ids.length === 0) {
+      return -1;
     }
-    order = compareStrings(g1, g2);
-    index++;
-  }
-  return order;
+
+    // we map the genres for each track and sort by name
+    const t1_genres = t1.genre_ids
+      .map((g) => genres[g].normalized_name)
+      .sort((g1, g2) => compareStrings(g1, g2));
+    const t2_genres = t2.genre_ids
+      .map((g) => genres[g].normalized_name)
+      .sort((g1, g2) => compareStrings(g1, g2));
+
+    // We loop over the sorted genres until we find a difference to sort by
+    let index = 0;
+    let order = 0;
+    while (order === 0) {
+      const g1 = t1_genres[index];
+      const g2 = t2_genres[index];
+
+      // If tracks share the same genres, but one track has one or more extra genre(s),
+      // we sort the track with more genres last
+      if (typeof g1 === "undefined" && typeof g2 === "undefined") {
+        return 0;
+      } else if (typeof g1 === "undefined") {
+        return -1;
+      } else if (typeof g2 === "undefined") {
+        return 1;
+      }
+      order = compareStrings(g1, g2);
+      index++;
+    }
+    return order;
+  };
 }
 
 export function compareAlbumsByTitleFirst(a1, a2) {

--- a/src/comparators.js
+++ b/src/comparators.js
@@ -43,6 +43,81 @@ export function compareTracks(albums) {
   };
 }
 
+export function compareTracksByArtist(t1, t2) {
+  // tracks without artists get sorted last
+  if (t1.track_artists.length === 0 && t2.track_artists.length === 0) {
+    return 0;
+  } else if (t1.track_artists.length === 0) {
+    return 1;
+  } else if (t2.track_artists.length === 0) {
+    return -1;
+  }
+
+  let order = 0;
+  let index = 0;
+  while (order === 0) {
+    const a1 = t1.track_artists[index];
+    const a2 = t2.track_artists[index];
+
+    // If tracks share the same artists, but one track has one or more extra artist(s),
+    // we sort the track with more artists last
+    if (typeof a1 === "undefined" && typeof a2 === "undefined") {
+      return 0;
+    } else if (typeof a1 === "undefined") {
+      return -1;
+    } else if (typeof a2 === "undefined") {
+      return 1;
+    }
+    order = compareStrings(a1.name, a2.name);
+    index++;
+  }
+  return order;
+}
+
+export function compareTracksByGenre(
+  t1,
+  t2,
+  genres = store.state.genres.genres
+) {
+  // tracks without genres get sorted last
+  if (t1.genre_ids.length === 0 && t2.genre_ids.length === 0) {
+    return 0;
+  } else if (t1.genre_ids.length === 0) {
+    return 1;
+  } else if (t2.genre_ids.length === 0) {
+    return -1;
+  }
+
+  // we map the genres for each track and sort by name
+  const t1_genres = t1.genre_ids
+    .map((g) => genres[g].normalized_name)
+    .sort((g1, g2) => compareStrings(g1, g2));
+  const t2_genres = t2.genre_ids
+    .map((g) => genres[g].normalized_name)
+    .sort((g1, g2) => compareStrings(g1, g2));
+
+  // We loop over the sorted genres until we find a difference to sort by
+  let index = 0;
+  let order = 0;
+  while (order === 0) {
+    const g1 = t1_genres[index];
+    const g2 = t2_genres[index];
+
+    // If tracks share the same genres, but one track has one or more extra genre(s),
+    // we sort the track with more genres last
+    if (typeof g1 === "undefined" && typeof g2 === "undefined") {
+      return 0;
+    } else if (typeof g1 === "undefined") {
+      return -1;
+    } else if (typeof g2 === "undefined") {
+      return 1;
+    }
+    order = compareStrings(g1, g2);
+    index++;
+  }
+  return order;
+}
+
 export function compareAlbumsByTitleFirst(a1, a2) {
   let order = compareStrings(a1.normalized_title, a2.normalized_title);
   order = order === 0 ? compareStrings(a1.release, a2.release) : order;

--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -195,6 +195,7 @@ export default {
     ...mapGetters("player", ["currentTrack"]),
     ...mapGetters("plays", ["playCountsByTrack"]),
     ...mapState("albums", ["albums"]),
+    ...mapState("genres", ["genres"]),
     ...mapState("tracks", { tracksObj: "tracks" }),
     filteredItems() {
       return this.tracks.filter(
@@ -228,10 +229,10 @@ export default {
       let sortFunction = null;
       switch (sortBy[0]) {
         case "album_id":
-          sortFunction = compareTracks;
+          sortFunction = compareTracks(this.albums);
           break;
         case "genre_ids":
-          sortFunction = compareTracksByGenre;
+          sortFunction = compareTracksByGenre(this.genres);
           break;
         case "length":
           sortFunction = (t1, t2) => t1.length - t2.length;

--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -27,6 +27,7 @@
       :page.sync="pagination.page"
       :show-select="isModerator"
       :single-select="singleSelect"
+      :custom-sort="sortFunction"
       class="elevation-3"
       ref="table"
       @item-selected="emitSelected"
@@ -104,6 +105,7 @@ import Searchable from "../mixins/Searchable";
 import TrackArtists from "./TrackArtists";
 import TrackGenres from "./TrackGenres";
 import MassEditDialog from "./MassEditDialog";
+import { compareStrings, compareTracks, compareTracksByArtist, compareTracksByGenre } from "@/comparators";
 
 export default {
   name: "TracksTable",
@@ -124,36 +126,36 @@ export default {
       {
         text: "#",
         value: "number",
-        sortable: false,
+        sortable: true,
         align: "end",
         width: "1px",
       },
       {
         text: this.$t("music.title"),
         value: "title",
-        sortable: false,
+        sortable: true,
       },
       {
         text: this.$t("music.track.length"),
         value: "length",
-        sortable: false,
+        sortable: true,
         align: "end",
         width: "1px",
       },
       {
         text: this.$tc("music.albums", 1),
         value: "album_id",
-        sortable: false,
+        sortable: true,
       },
       {
         text: this.$t("music.artist.artist-s"),
         value: "track_artists",
-        sortable: false,
+        sortable: true,
       },
       {
         text: this.$t("music.genre-s"),
         value: "genre_ids",
-        sortable: false,
+        sortable: true,
       },
       {
         text: this.$t("music.play-count"),
@@ -214,6 +216,31 @@ export default {
     },
     reloadSelected() {
       this.selected = this.selected.map((s) => this.tracksObj[s.id]);
+    },
+    sortFunction(items, sortBy, sortDesc) {
+      let sortFunction = null;
+      switch (sortBy[0]) {
+        case "album_id":
+          sortFunction = compareTracks;
+          break;
+        case "genre_ids":
+          sortFunction = compareTracksByGenre;
+          break;
+        case "length":
+          sortFunction = (t1, t2) => t1.length - t2.length;
+          break;
+        case "number":
+          sortFunction = (t1, t2) => t1.number - t2.number;
+          break;
+        case "title":
+          sortFunction = (t1, t2) =>
+            compareStrings(t1.normalized_title, t2.normalized_title);
+          break;
+        case "track_artists":
+          sortFunction = compareTracksByArtist;
+      }
+      const sorted = sortFunction ? items.sort(sortFunction) : items;
+      return sortDesc[0] ? sorted.reverse() : sorted;
     },
   },
 };

--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -166,7 +166,6 @@ export default {
       {
         text: this.$t("music.play-count"),
         value: "play_count",
-        sortable: false,
         align: "end",
         width: "1px",
       },
@@ -239,6 +238,10 @@ export default {
           break;
         case "number":
           sortFunction = (t1, t2) => t1.number - t2.number;
+          break;
+        case "play_count":
+          sortFunction = (t1, t2) =>
+            (this.playCountsByTrack[t1] = this.playCountsByTrack[t2]);
           break;
         case "title":
           sortFunction = (t1, t2) =>

--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -132,35 +132,36 @@ export default {
         text: "#",
         value: "number",
         sortable: true,
-        align: "end",
+        align: "center",
         width: "1px",
+        class: "text-no-wrap",
       },
       {
         text: this.$t("music.title"),
         value: "title",
-        sortable: true,
+        class: "text-no-wrap",
       },
       {
         text: this.$t("music.track.length"),
         value: "length",
-        sortable: true,
         align: "end",
         width: "1px",
+        class: "text-no-wrap",
       },
       {
         text: this.$tc("music.albums", 1),
         value: "album_id",
-        sortable: true,
+        class: "text-no-wrap",
       },
       {
         text: this.$t("music.artist.artist-s"),
         value: "track_artists",
-        sortable: true,
+        class: "text-no-wrap",
       },
       {
         text: this.$t("music.genre-s"),
         value: "genre_ids",
-        sortable: true,
+        class: "text-no-wrap",
       },
       {
         text: this.$t("music.play-count"),
@@ -175,6 +176,7 @@ export default {
         sortable: false,
         align: "end",
         width: "1px",
+        class: "text-no-wrap",
       },
     ];
     if (!this.showAlbum) {

--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -105,7 +105,12 @@ import Searchable from "../mixins/Searchable";
 import TrackArtists from "./TrackArtists";
 import TrackGenres from "./TrackGenres";
 import MassEditDialog from "./MassEditDialog";
-import { compareStrings, compareTracks, compareTracksByArtist, compareTracksByGenre } from "@/comparators";
+import {
+  compareStrings,
+  compareTracks,
+  compareTracksByArtist,
+  compareTracksByGenre,
+} from "@/comparators";
 
 export default {
   name: "TracksTable",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,9 +9,12 @@
 		"dataTable": {
 			"itemsPerPageText": "Rows per page:",
 			"ariaLabel": {
-				"sortDescending": ": Sorted descending. Activate to remove sorting.",
-				"sortAscending": ": Sorted ascending. Activate to sort descending.",
-				"sortNone": ": Not sorted. Activate to sort ascending."
+				"sortDescending": "Sorted descending.",
+				"sortAscending": "Sorted ascending.",
+				"sortNone": "Not sorted.",
+				"activateNone": "Activate to remove sorting.",
+				"activateDescending": "Activate to sort descending.",
+				"activateAscending": "Activate to sort ascending."
 			},
 			"sortBy": "Sort by"
 		},

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -9,9 +9,12 @@
 		"dataTable": {
 			"itemsPerPageText": "Rijen per pagina:",
 			"ariaLabel": {
-				"sortDescending": ": Aflopend gesorteerd. Activeer om sorteren ongedaan te maken.",
-				"sortAscending": ": Oplopend gesorteerd. Activeer om aflopend te sorteren.",
-				"sortNone": ": Niet gesorteerd. Activeer om oplopend te sorteren"
+				"sortDescending": "Aflopend gesorteerd.",
+				"sortAscending": "Oplopend gesorteerd.",
+				"sortNone": "Niet gesorteerd.",
+				"activateNone": "Activeer om sorteren ongedaan te maken.",
+				"activateDescending": "Activeer om aflopend te sorteren.",
+				"activateAscending": "Activeer om oplopend te sorteren."
 			},
 			"sortBy": "Sorteer volgens"
 		},

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -224,12 +224,12 @@ export default {
         compareTracks(rootState.albums.albums)
       );
     },
-    tracksEmpty: (state, getters, rootState) => {
+    tracksEmpty: (state, getters) => {
       return getters.tracks
         .filter((t) => t.length === null)
         .sort(compareTracks(rootState.albums.albums));
     },
-    tracksFlagged: (state, getters, rootState) => {
+    tracksFlagged: (state, getters) => {
       return getters.tracks
         .filter((t) => t.review_comment !== null)
         .sort(compareTracks(rootState.albums.albums));

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -224,12 +224,12 @@ export default {
         compareTracks(rootState.albums.albums)
       );
     },
-    tracksEmpty: (state, getters) => {
+    tracksEmpty: (state, getters, rootState) => {
       return getters.tracks
         .filter((t) => t.length === null)
         .sort(compareTracks(rootState.albums.albums));
     },
-    tracksFlagged: (state, getters) => {
+    tracksFlagged: (state, getters, rootState) => {
       return getters.tracks
         .filter((t) => t.review_comment !== null)
         .sort(compareTracks(rootState.albums.albums));


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

# Description

Allows the user to sort the TrackTable for all relevant properties by providing the `VDataTable` with a method to sort all properties. If the user doesn't determine the sort, the items are sorted as provided to the component.

* `compareTracks` takes an album array as an optional param. I had first reworked this to take an array of albums rather than the rootState, but it makes more sense to not require any array.
* The `TrackTable` has one method to sort all items. (Vuetify also allows a `sort` prop in the header, but this only has access to that prop, which doesn't work for us. We often need the whole track.) This method only uses the first item of `sortBy` and `sortDesc` since I have not enabled `multiSort`
* Added a function to sort tracks by genres or artists.
* Headers all have a class `text-no-wrap`. Without this the icon to sort would often appear underneath or above the header, which make for a very ugly layout.

# How Has This Been Tested?

Extensive local tests to make sure properties are sorted as expected.
