### PR TITLE
(Re)load content on main objects pages

### DIFF
--- a/src/api/albums.js
+++ b/src/api/albums.js
@@ -7,8 +7,8 @@ import {
   destroyEmpty as genDestroyEmpty,
 } from "./fetch";
 
-export function index(auth) {
-  return indexGenerator("albums", auth);
+export function index(auth, scope) {
+  return indexGenerator("albums", auth, scope);
 }
 
 export function create(auth, album) {

--- a/src/api/artists.js
+++ b/src/api/artists.js
@@ -8,8 +8,8 @@ import {
   merge as genMerge,
 } from "./fetch";
 
-export function index(auth) {
-  return indexGenerator("artists", auth);
+export function index(auth, scope) {
+  return indexGenerator("artists", auth, scope);
 }
 
 export function create(auth, artist) {

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -6,19 +6,22 @@ const fetchRetry = require("fetch-retry")(fetch, {
   },
 });
 
-export async function* indexGenerator(path, auth) {
+export async function* indexGenerator(path, auth, scope = { finalQuery: "" }) {
   let page = 1;
   while (true) {
     let response, result;
     try {
-      response = await fetchRetry(`${baseURL}/${path}?page=${page}`, {
-        retries: 5,
-        method: "GET",
-        headers: {
-          "x-secret": auth.secret,
-          "x-device-id": auth.device_id,
-        },
-      });
+      response = await fetchRetry(
+        `${baseURL}/${path}?page=${page}${scope.finalQuery}`,
+        {
+          retries: 5,
+          method: "GET",
+          headers: {
+            "x-secret": auth.secret,
+            "x-device-id": auth.device_id,
+          },
+        }
+      );
       result = await response.json();
     } catch (reason) {
       throw { error: [reason] };

--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -1,4 +1,5 @@
 import baseURL from "./base_url";
+import { Scope } from "./scopes";
 const fetchRetry = require("fetch-retry")(fetch, {
   retries: 0,
   retryDelay: function (attempt) {
@@ -6,7 +7,7 @@ const fetchRetry = require("fetch-retry")(fetch, {
   },
 });
 
-export async function* indexGenerator(path, auth, scope = { finalQuery: "" }) {
+export async function* indexGenerator(path, auth, scope = new Scope()) {
   let page = 1;
   while (true) {
     let response, result;

--- a/src/api/scopes.js
+++ b/src/api/scopes.js
@@ -5,52 +5,55 @@ export class Scope {
     return this.scopes.map((s) => `&${s.key}=${s.query}`).join("");
   }
 
-  addScope = (key, query) => {
+  addScope(key, query) {
     this.scopes.push({ key, query });
     return this;
-  };
+  }
 
-  addScopesFromArray = (key, queries) => {
+  addScopesFromArray(key, queries) {
     queries.forEach((q) => this.addScope(key, q));
     return this;
-  };
+  }
 }
 
 export class AlbumsScope extends Scope {
-  artist = (id) => {
+  artist(id) {
     return this.addScope("artist_id", id);
-  };
+  }
 
-  filter = (string) => {
+  filter(string) {
     return this.addScope("filter", string);
-  };
+  }
 
-  label = (id) => {
+  label(id) {
     return this.addScope("label", id);
-  };
+  }
 
-  labels = (ids) => {
+  labels(ids) {
     return this.addScopesFromArray("labels", ids);
-  };
+  }
 }
 
 export class ArtistsScope extends Scope {
-  filter = (string) => {
+  filter(string) {
     return this.addScope("filter", string);
-  };
+  }
 }
 
 export class TracksScope extends Scope {
-  album = (id) => {
+  album(id) {
     return this.addScope("album_id", id);
-  };
-  artist = (id) => {
+  }
+
+  artist(id) {
     return this.addScope("artist_id", id);
-  };
-  filter = (string) => {
+  }
+
+  filter(string) {
     return this.addScope("filter", string);
-  };
-  genre = (id) => {
+  }
+
+  genre(id) {
     return this.addScope("genre_id", id);
-  };
+  }
 }

--- a/src/api/scopes.js
+++ b/src/api/scopes.js
@@ -6,28 +6,12 @@ export class Scope {
   }
 
   addScope = (key, query) => {
-    if (typeof query !== "string" && typeof query !== "number") {
-      throw TypeError(
-        `${query} is an ${typeof query} while your scope '${key}' that expects a string or number.`
-      );
-    }
     this.scopes.push({ key, query });
     return this;
   };
 
   addScopesFromArray = (key, queries) => {
-    if (!Array.isArray(queries)) {
-      throw TypeError(
-        `${queries} is an ${typeof queries} while your scope '${key}' that expects an array with strings or numbers.`
-      );
-    }
-    try {
-      queries.forEach((q) => this.addScope(key, q));
-    } catch (e) {
-      throw TypeError(
-        `One of the values in your array is not a string or number:\n${e.message}`
-      );
-    }
+    queries.forEach((q) => this.addScope(key, q));
     return this;
   };
 }

--- a/src/api/scopes.js
+++ b/src/api/scopes.js
@@ -1,0 +1,62 @@
+class Scope {
+  constructor() {
+    this.finalQuery = "";
+  }
+
+  queryFromArray = (param, queries) => {
+    queries.forEach((q) => {
+      this.finalQuery += `&${param}=${q}`;
+    });
+    return this;
+  };
+
+  queryFromString = (param, query) => {
+    if (typeof query !== "string" && typeof query !== "number") {
+      // This error should only be encountered while developing
+      throw TypeError(
+        `You passed an ${typeof query} to a scope that expects a string or number`
+      );
+    }
+    this.finalQuery += `&${param}=${query}`;
+    return this;
+  };
+}
+
+export class AlbumsScope extends Scope {
+  artist = (id) => {
+    return this.queryFromString("artist_id", id);
+  };
+
+  filter = (string) => {
+    return this.queryFromString("filter", string);
+  };
+
+  label = (id) => {
+    return this.queryFromString("label", id);
+  };
+
+  labels = (ids) => {
+    return this.queryFromArray("labels", ids);
+  };
+}
+
+export class ArtistsScope extends Scope {
+  filter = (string) => {
+    return this.queryFromString("filter", string);
+  };
+}
+
+export class TracksScope extends Scope {
+  album = (id) => {
+    return this.queryFromString("album_id", id);
+  };
+  artist = (id) => {
+    return this.queryFromString("artist_id", id);
+  };
+  filter = (string) => {
+    return this.queryFromString("filter", string);
+  };
+  genre = (id) => {
+    return this.queryFromString("genre_id", id);
+  };
+}

--- a/src/api/scopes.js
+++ b/src/api/scopes.js
@@ -1,62 +1,72 @@
-class Scope {
-  constructor() {
-    this.finalQuery = "";
+export class Scope {
+  scopes = [];
+
+  get finalQuery() {
+    return this.scopes.map((s) => `&${s.key}=${s.query}`).join("");
   }
 
-  queryFromArray = (param, queries) => {
-    queries.forEach((q) => {
-      this.finalQuery += `&${param}=${q}`;
-    });
+  addScope = (key, query) => {
+    if (typeof query !== "string" && typeof query !== "number") {
+      throw TypeError(
+        `${query} is an ${typeof query} while your scope '${key}' that expects a string or number.`
+      );
+    }
+    this.scopes.push({ key, query });
     return this;
   };
 
-  queryFromString = (param, query) => {
-    if (typeof query !== "string" && typeof query !== "number") {
-      // This error should only be encountered while developing
+  addScopesFromArray = (key, queries) => {
+    if (!Array.isArray(queries)) {
       throw TypeError(
-        `You passed an ${typeof query} to a scope that expects a string or number`
+        `${queries} is an ${typeof queries} while your scope '${key}' that expects an array with strings or numbers.`
       );
     }
-    this.finalQuery += `&${param}=${query}`;
+    try {
+      queries.forEach((q) => this.addScope(key, q));
+    } catch (e) {
+      throw TypeError(
+        `One of the values in your array is not a string or number:\n${e.message}`
+      );
+    }
     return this;
   };
 }
 
 export class AlbumsScope extends Scope {
   artist = (id) => {
-    return this.queryFromString("artist_id", id);
+    return this.addScope("artist_id", id);
   };
 
   filter = (string) => {
-    return this.queryFromString("filter", string);
+    return this.addScope("filter", string);
   };
 
   label = (id) => {
-    return this.queryFromString("label", id);
+    return this.addScope("label", id);
   };
 
   labels = (ids) => {
-    return this.queryFromArray("labels", ids);
+    return this.addScopesFromArray("labels", ids);
   };
 }
 
 export class ArtistsScope extends Scope {
   filter = (string) => {
-    return this.queryFromString("filter", string);
+    return this.addScope("filter", string);
   };
 }
 
 export class TracksScope extends Scope {
   album = (id) => {
-    return this.queryFromString("album_id", id);
+    return this.addScope("album_id", id);
   };
   artist = (id) => {
-    return this.queryFromString("artist_id", id);
+    return this.addScope("artist_id", id);
   };
   filter = (string) => {
-    return this.queryFromString("filter", string);
+    return this.addScope("filter", string);
   };
   genre = (id) => {
-    return this.queryFromString("genre_id", id);
+    return this.addScope("genre_id", id);
   };
 }

--- a/src/api/tracks.js
+++ b/src/api/tracks.js
@@ -7,8 +7,8 @@ import {
   merge as genMerge,
 } from "./fetch";
 
-export function index(auth) {
-  return indexGenerator("tracks", auth);
+export function index(auth, scope) {
+  return indexGenerator("tracks", auth, scope);
 }
 
 export function create(auth, track) {

--- a/src/router.js
+++ b/src/router.js
@@ -117,6 +117,7 @@ const router = new Router({
           path: "labels/:id",
           name: "label",
           component: Label,
+          props: true,
         },
         {
           path: "labels/:id/edit",

--- a/src/router.js
+++ b/src/router.js
@@ -80,6 +80,7 @@ const router = new Router({
           path: "artists/:id",
           name: "artist",
           component: Artist,
+          props: true,
         },
         {
           path: "artists/:id/edit",

--- a/src/router.js
+++ b/src/router.js
@@ -59,6 +59,7 @@ const router = new Router({
           path: "albums/:id",
           name: "album",
           component: Album,
+          props: true,
         },
         {
           path: "albums/:id/edit",

--- a/src/router.js
+++ b/src/router.js
@@ -101,6 +101,7 @@ const router = new Router({
           path: "genres/:id",
           name: "genre",
           component: Genre,
+          props: true,
         },
         {
           path: "genres/:id/edit",

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,4 +1,4 @@
-export async function fetchAll(commit, generator, commitAction) {
+export async function fetchAll(commit, generator, commitAction, scope = null) {
   commit("setStartLoading");
   let done = false;
   let results = [];
@@ -13,5 +13,8 @@ export async function fetchAll(commit, generator, commitAction) {
     }
   }
   commit(commitAction, results);
-  commit("removeOld");
+  // If a scope is present, we skip removeOld
+  if (scope === null) {
+    commit("removeOld");
+  }
 }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -14,7 +14,7 @@ export async function fetchAll(commit, generator, commitAction, scope = null) {
   }
   commit(commitAction, results);
   // If a scope is present, we skip removeOld
-  if (scope === null) {
+  if (scope !== null) {
     commit("removeOld");
   }
 }

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -12,6 +12,7 @@ import {
   compareAlbumsByReleaseFirst,
   compareAlbumsByTitleFirst,
 } from "../comparators";
+import { AlbumsScope } from "../api/scopes";
 
 export default {
   namespaced: true,
@@ -104,7 +105,7 @@ export default {
     },
   },
   actions: {
-    async index({ commit, rootState }, scope) {
+    async index({ commit, rootState }, scope = new AlbumsScope()) {
       const generator = index(rootState.auth, scope);
       try {
         await fetchAll(commit, generator, "setAlbums", scope);

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -104,10 +104,10 @@ export default {
     },
   },
   actions: {
-    async index({ commit, rootState }) {
-      const generator = index(rootState.auth);
+    async index({ commit, rootState }, scope) {
+      const generator = index(rootState.auth, scope);
       try {
-        await fetchAll(commit, generator, "setAlbums");
+        await fetchAll(commit, generator, "setAlbums", scope);
         return true;
       } catch (error) {
         commit("addError", error, { root: true });

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -54,10 +54,10 @@ export default {
     },
   },
   actions: {
-    async index({ commit, rootState }) {
-      const generator = index(rootState.auth);
+    async index({ commit, rootState }, scope) {
+      const generator = index(rootState.auth, scope);
       try {
-        await fetchAll(commit, generator, "setArtists");
+        await fetchAll(commit, generator, "setArtists", scope);
         return true;
       } catch (error) {
         commit("addError", error, { root: true });

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -10,6 +10,7 @@ import {
 } from "../api/artists";
 import { fetchAll } from "./actions";
 import { compareStrings } from "../comparators";
+import { ArtistsScope } from "../api/scopes";
 
 export default {
   namespaced: true,
@@ -54,7 +55,7 @@ export default {
     },
   },
   actions: {
-    async index({ commit, rootState }, scope) {
+    async index({ commit, rootState }, scope = new ArtistsScope()) {
       const generator = index(rootState.auth, scope);
       try {
         await fetchAll(commit, generator, "setArtists", scope);

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -2,6 +2,7 @@ import Vue from "vue";
 import { index, create, destroy, update, read, merge } from "../api/tracks";
 import { fetchAll } from "./actions";
 import { compareTracks } from "../comparators";
+import { TracksScope } from "../api/scopes";
 
 export default {
   namespaced: true,
@@ -97,7 +98,7 @@ export default {
     },
   },
   actions: {
-    async index({ commit, rootState }, scope) {
+    async index({ commit, rootState }, scope = new TracksScope()) {
       const generator = index(rootState.auth, scope);
       try {
         await fetchAll(commit, generator, "setTracks", scope);

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -97,10 +97,10 @@ export default {
     },
   },
   actions: {
-    async index({ commit, rootState }) {
-      const generator = index(rootState.auth);
+    async index({ commit, rootState }, scope) {
+      const generator = index(rootState.auth, scope);
       try {
-        await fetchAll(commit, generator, "setTracks");
+        await fetchAll(commit, generator, "setTracks", scope);
         return true;
       } catch (error) {
         commit("addError", error, { root: true });

--- a/src/views/albums/Album.vue
+++ b/src/views/albums/Album.vue
@@ -85,10 +85,7 @@ export default {
     };
   },
   watch: {
-    id: {
-      handler: "fetchContent",
-      immediate: true,
-    },
+    id: "fetchContent",
   },
   computed: {
     ...mapState("albums", ["albums"]),

--- a/src/views/albums/Album.vue
+++ b/src/views/albums/Album.vue
@@ -75,7 +75,7 @@ export default {
   },
   props: {
     id: {
-      type: [String],
+      type: [String, Number],
       required: true,
     },
   },

--- a/src/views/albums/Album.vue
+++ b/src/views/albums/Album.vue
@@ -75,7 +75,7 @@ export default {
   },
   props: {
     id: {
-      type: [String, Number],
+      type: [String],
       required: true,
     },
   },
@@ -119,12 +119,11 @@ export default {
 
       const album = this.read(this.id);
       const tracks = this.indexTracks(new TracksScope().album(this.id));
-      Promise.all([album, tracks]).finally(() => {
-        // If the album is undefined after loading, we assume that it doesn't exist.
-        if (this.album === undefined) {
-          this.$router.go(-1);
-        }
-      });
+      await Promise.all([album, tracks]);
+      // If the album is undefined after loading, we assume that it doesn't exist.
+      if (this.album === undefined) {
+        this.$router.go(-1);
+      }
     },
     setImageUnavailable() {
       this.imageUnavailable = true;

--- a/src/views/albums/Album.vue
+++ b/src/views/albums/Album.vue
@@ -85,7 +85,10 @@ export default {
     };
   },
   watch: {
-    id: "fetchContent",
+    id: {
+      handler: "fetchContent",
+      immediate: true,
+    },
   },
   computed: {
     ...mapState("albums", ["albums"]),
@@ -107,7 +110,13 @@ export default {
   methods: {
     ...mapActions("albums", ["read"]),
     ...mapActions("tracks", { indexTracks: "index" }),
-    async fetchContent() {
+    async fetchContent(newValue, oldValue) {
+      // After loading the content, the router will change the id from a string to a number
+      // but we don't actually want to load the content twice
+      if (newValue == oldValue) {
+        return;
+      }
+
       const album = this.read(this.id);
       const tracks = this.indexTracks(new TracksScope().album(this.id));
       Promise.all([album, tracks]).finally(() => {

--- a/src/views/artists/Artist.vue
+++ b/src/views/artists/Artist.vue
@@ -82,7 +82,10 @@ export default {
     };
   },
   watch: {
-    id: "fetchContent",
+    id: {
+      handler: "fetchContent",
+      immediate: true,
+    },
   },
   computed: {
     ...mapGetters("auth", ["isModerator"]),
@@ -105,7 +108,13 @@ export default {
     ...mapActions("albums", { indexAlbums: "index" }),
     ...mapActions("artists", ["read"]),
     ...mapActions("tracks", { indexTracks: "index" }),
-    async fetchContent() {
+    async fetchContent(newValue, oldValue) {
+      // After loading the content, the router will change the id from a string to a number
+      // but we don't actually want to load the content twice
+      if (newValue == oldValue) {
+        return;
+      }
+
       const artist = this.read(this.id);
       const albums = this.indexAlbums(new AlbumsScope().artist(this.id));
       const tracks = this.indexTracks(new TracksScope().artist(this.id));

--- a/src/views/artists/Artist.vue
+++ b/src/views/artists/Artist.vue
@@ -118,12 +118,11 @@ export default {
       const artist = this.read(this.id);
       const albums = this.indexAlbums(new AlbumsScope().artist(this.id));
       const tracks = this.indexTracks(new TracksScope().artist(this.id));
-      Promise.all([artist, albums, tracks]).finally(() => {
-        // If the artist is undefined after loading, we assume that it doesn't exist.
-        if (this.artist === undefined) {
-          this.$router.go(-1);
-        }
-      });
+      await Promise.all([artist, albums, tracks]);
+      // If the artist is undefined after loading, we assume that it doesn't exist.
+      if (this.artist === undefined) {
+        this.$router.go(-1);
+      }
     },
     setImageUnavailable() {
       this.imageUnavailable = true;

--- a/src/views/genres/Genre.vue
+++ b/src/views/genres/Genre.vue
@@ -37,7 +37,10 @@ export default {
     },
   },
   watch: {
-    id: "fetchContent",
+    id: {
+      handler: "fetchContent",
+      immediate: true,
+    },
   },
   computed: {
     ...mapGetters("auth", ["isModerator"]),
@@ -54,7 +57,13 @@ export default {
   methods: {
     ...mapActions("genres", ["read"]),
     ...mapActions("tracks", { indexTracks: "index" }),
-    async fetchContent() {
+    async fetchContent(newValue, oldValue) {
+      // After loading the content, the router will change the id from a string to a number
+      // but we don't actually want to load the content twice
+      if (newValue == oldValue) {
+        return;
+      }
+
       const genre = this.read(this.id);
       const tracks = this.indexTracks(new TracksScope().genre(this.id));
       Promise.all([genre, tracks]).finally(() => {

--- a/src/views/genres/Genre.vue
+++ b/src/views/genres/Genre.vue
@@ -66,12 +66,11 @@ export default {
 
       const genre = this.read(this.id);
       const tracks = this.indexTracks(new TracksScope().genre(this.id));
-      Promise.all([genre, tracks]).finally(() => {
-        // If the genre is undefined after loading, we assume that it doesn't exist.
-        if (this.genre === undefined) {
-          this.$router.go(-1);
-        }
-      });
+      await Promise.all([genre, tracks]);
+      // If the genre is undefined after loading, we assume that it doesn't exist.
+      if (this.genre === undefined) {
+        this.$router.go(-1);
+      }
     },
   },
 };

--- a/src/views/labels/Label.vue
+++ b/src/views/labels/Label.vue
@@ -74,7 +74,10 @@ export default {
     },
   },
   watch: {
-    id: "fetchContent",
+    id: {
+      handler: "fetchContent",
+      immediate: true,
+    },
   },
   computed: {
     ...mapGetters("auth", ["isModerator"]),
@@ -101,7 +104,13 @@ export default {
   methods: {
     ...mapActions("albums", ["read"]),
     ...mapActions("albums", { indexAlbums: "index" }),
-    async fetchContent() {
+    async fetchContent(newValue, oldValue) {
+      // After loading the content, the router will change the id from a string to a number
+      // but we don't actually want to load the content twice
+      if (newValue == oldValue) {
+        return;
+      }
+
       const label = this.read(this.id);
       const albums = this.indexAlbums(new AlbumsScope().label(this.id));
       Promise.all([label, albums]).finally(() => {

--- a/src/views/labels/Label.vue
+++ b/src/views/labels/Label.vue
@@ -102,7 +102,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions("albums", ["read"]),
+    ...mapActions("labels", ["read"]),
     ...mapActions("albums", { indexAlbums: "index" }),
     async fetchContent(newValue, oldValue) {
       // After loading the content, the router will change the id from a string to a number

--- a/src/views/labels/Label.vue
+++ b/src/views/labels/Label.vue
@@ -113,12 +113,11 @@ export default {
 
       const label = this.read(this.id);
       const albums = this.indexAlbums(new AlbumsScope().label(this.id));
-      Promise.all([label, albums]).finally(() => {
-        // If the label is undefined after loading, we assume that it doesn't exist.
-        if (this.label === undefined) {
-          this.$router.go(-1);
-        }
-      });
+      await Promise.all([label, albums]);
+      // If the label is undefined after loading, we assume that it doesn't exist.
+      if (this.label === undefined) {
+        this.$router.go(-1);
+      }
     },
   },
 };


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

# Description
This PR adds all functionality to (re)load the content on the main object pages (Album, Artist, Genre, Label).
This means:
* Going directly to a specifc page (`app/albums/1`) will get content and functionality almost instantly.
* Content is much more likely to stay up to date.

There are two drawbacks to this:
* We introduce a lot more API calls. Every page for a main object will do 2 -3 API calls. I would try this and see if it creates issues/too much traffic. If so, we can check `object.loaded` before calling the api and only call the API if the content is older than some timeperiod.
* There is a higher chance that related content is missing. This is something that should/will be added in a future PR.

## Scopes
To accomplish this, I've added a few scopes classes to our api interface.
These classes allow the user to easily create a scope without bothering with the implementation on the api-side.
A scope can be:
* created on a single line `new AlbumsScope.label(id)`
* chained for more complex queries `new AlbumsScope.label(id).artist(id).filter(string)`
* created and then modified:
```
const scope = new Albumscope()
scope.label(id)
scope.artist(id)
scope.finalQuery
```

The scope class throws errors if we pass it the wrong kind of parameter. This errors are not translated since the end-user should not encounter these. They are only their to notify the develop if they made an error when building scopes.

If we use a scope, we skip `removeOld` after fetching all data. In the future, we might want to allow that method check whether any objects that fit the scope should be removed, but IMHO that is not really relevant. (If a user visits the page for an object that doesn't exist on the api anymore, they will get an error and go back to the previous page).


# How Has This Been Tested?

- [x] Local tests to see if everything works
- [x] A quick test with our production api, as a final check.
