### PR TITLE
Cache vuex store

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@mdi/svg": "^5.9.55",
     "fetch-retry": "^4.1.1",
     "localforage": "^1.9.0",
+    "lodash.debounce": "^4.0.8",
     "roboto-fontface": "^0.10.0",
     "vue": "^2.6.14",
     "vue-i18n": "^8.24.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@mdi/font": "^5.9.55",
     "@mdi/svg": "^5.9.55",
     "fetch-retry": "^4.1.1",
+    "localforage": "^1.9.0",
     "roboto-fontface": "^0.10.0",
     "vue": "^2.6.14",
     "vue-i18n": "^8.24.5",
@@ -20,7 +21,7 @@
     "vuedraggable": "^2.24.3",
     "vuetify": "^2.5.6",
     "vuex": "^3.6.2",
-    "vuex-persistedstate": "^3.2.0"
+    "vuex-persist": "^3.1.3"
   },
   "devDependencies": {
     "@intlify/vue-i18n-loader": "^1.1.0",

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -13,6 +13,7 @@ import {
   compareAlbumsByTitleFirst,
 } from "../comparators";
 import { AlbumsScope } from "../api/scopes";
+import store from "./store";
 
 export default {
   namespaced: true,
@@ -108,6 +109,7 @@ export default {
     async index({ commit, rootState }, scope = new AlbumsScope()) {
       const generator = index(rootState.auth, scope);
       try {
+        await store.restored;
         await fetchAll(commit, generator, "setAlbums", scope);
         return true;
       } catch (error) {
@@ -128,6 +130,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
+        await store.restored;
         commit("setAlbum", { id, album: result });
         return result.id;
       } catch (error) {

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -109,7 +109,7 @@ export default {
     async index({ commit, rootState }, scope = new AlbumsScope()) {
       const generator = index(rootState.auth, scope);
       try {
-        await store.restored;
+        await store.albumsRestored;
         await fetchAll(commit, generator, "setAlbums", scope);
         return true;
       } catch (error) {
@@ -130,7 +130,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
-        await store.restored;
+        await store.albumsRestored;
         commit("setAlbum", { id, album: result });
         return result.id;
       } catch (error) {

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -13,7 +13,6 @@ import {
   compareAlbumsByTitleFirst,
 } from "../comparators";
 import { AlbumsScope } from "../api/scopes";
-import store from "./store";
 
 export default {
   namespaced: true,
@@ -109,7 +108,7 @@ export default {
     async index({ commit, rootState }, scope = new AlbumsScope()) {
       const generator = index(rootState.auth, scope);
       try {
-        await store.albumsRestored;
+        await this.albumsRestored;
         await fetchAll(commit, generator, "setAlbums", scope);
         return true;
       } catch (error) {
@@ -130,7 +129,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
-        await store.albumsRestored;
+        await this.albumsRestored;
         commit("setAlbum", { id, album: result });
         return result.id;
       } catch (error) {

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -11,6 +11,7 @@ import {
 import { fetchAll } from "./actions";
 import { compareStrings } from "../comparators";
 import { ArtistsScope } from "../api/scopes";
+import store from "./store";
 
 export default {
   namespaced: true,
@@ -58,6 +59,7 @@ export default {
     async index({ commit, rootState }, scope = new ArtistsScope()) {
       const generator = index(rootState.auth, scope);
       try {
+        await store.restored;
         await fetchAll(commit, generator, "setArtists", scope);
         return true;
       } catch (error) {
@@ -78,6 +80,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
+        await store.restored;
         commit("setArtist", { id, artist: result });
         return result.id;
       } catch (error) {

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -11,7 +11,6 @@ import {
 import { fetchAll } from "./actions";
 import { compareStrings } from "../comparators";
 import { ArtistsScope } from "../api/scopes";
-import store from "./store";
 
 export default {
   namespaced: true,
@@ -59,7 +58,7 @@ export default {
     async index({ commit, rootState }, scope = new ArtistsScope()) {
       const generator = index(rootState.auth, scope);
       try {
-        await store.artistsRestored;
+        await this.artistsRestored;
         await fetchAll(commit, generator, "setArtists", scope);
         return true;
       } catch (error) {
@@ -80,7 +79,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
-        await store.artistsRestored;
+        await this.artistsRestored;
         commit("setArtist", { id, artist: result });
         return result.id;
       } catch (error) {

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -59,7 +59,7 @@ export default {
     async index({ commit, rootState }, scope = new ArtistsScope()) {
       const generator = index(rootState.auth, scope);
       try {
-        await store.restored;
+        await store.artistsRestored;
         await fetchAll(commit, generator, "setArtists", scope);
         return true;
       } catch (error) {
@@ -80,7 +80,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
-        await store.restored;
+        await store.artistsRestored;
         commit("setArtist", { id, artist: result });
         return result.id;
       } catch (error) {

--- a/src/store/genres.js
+++ b/src/store/genres.js
@@ -10,6 +10,7 @@ import {
 } from "../api/genres";
 import { fetchAll } from "./actions";
 import { compareStrings } from "../comparators";
+import store from "./store";
 
 export default {
   namespaced: true,
@@ -57,6 +58,7 @@ export default {
     async index({ commit, rootState }) {
       const generator = index(rootState.auth);
       try {
+        await store.restored;
         await fetchAll(commit, generator, "setGenres");
         return true;
       } catch (error) {
@@ -77,6 +79,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
+        await store.restored;
         commit("setGenre", { id, genre: result });
         return result.id;
       } catch (error) {

--- a/src/store/genres.js
+++ b/src/store/genres.js
@@ -58,7 +58,7 @@ export default {
     async index({ commit, rootState }) {
       const generator = index(rootState.auth);
       try {
-        await store.restored;
+        await store.genresRestored;
         await fetchAll(commit, generator, "setGenres");
         return true;
       } catch (error) {
@@ -79,7 +79,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
-        await store.restored;
+        await store.genresRestored;
         commit("setGenre", { id, genre: result });
         return result.id;
       } catch (error) {

--- a/src/store/genres.js
+++ b/src/store/genres.js
@@ -10,7 +10,6 @@ import {
 } from "../api/genres";
 import { fetchAll } from "./actions";
 import { compareStrings } from "../comparators";
-import store from "./store";
 
 export default {
   namespaced: true,
@@ -58,7 +57,7 @@ export default {
     async index({ commit, rootState }) {
       const generator = index(rootState.auth);
       try {
-        await store.genresRestored;
+        await this.genresRestored;
         await fetchAll(commit, generator, "setGenres");
         return true;
       } catch (error) {
@@ -79,7 +78,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
-        await store.genresRestored;
+        await this.genresRestored;
         commit("setGenre", { id, genre: result });
         return result.id;
       } catch (error) {

--- a/src/store/labels.js
+++ b/src/store/labels.js
@@ -58,7 +58,7 @@ export default {
     async index({ commit, rootState }) {
       const generator = index(rootState.auth);
       try {
-        await store.restored;
+        await store.labelsRestored;
         await fetchAll(commit, generator, "setLabels");
         return true;
       } catch (error) {
@@ -79,7 +79,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
-        await store.restored;
+        await store.labelsRestored;
         commit("setLabel", { id, label: result });
         return result.id;
       } catch (error) {

--- a/src/store/labels.js
+++ b/src/store/labels.js
@@ -10,7 +10,6 @@ import {
 } from "../api/labels";
 import { fetchAll } from "./actions";
 import { compareStrings } from "../comparators";
-import store from "./store";
 
 export default {
   namespaced: true,
@@ -58,7 +57,7 @@ export default {
     async index({ commit, rootState }) {
       const generator = index(rootState.auth);
       try {
-        await store.labelsRestored;
+        await this.labelsRestored;
         await fetchAll(commit, generator, "setLabels");
         return true;
       } catch (error) {
@@ -79,7 +78,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
-        await store.labelsRestored;
+        await this.labelsRestored;
         commit("setLabel", { id, label: result });
         return result.id;
       } catch (error) {

--- a/src/store/labels.js
+++ b/src/store/labels.js
@@ -10,6 +10,7 @@ import {
 } from "../api/labels";
 import { fetchAll } from "./actions";
 import { compareStrings } from "../comparators";
+import store from "./store";
 
 export default {
   namespaced: true,
@@ -57,6 +58,7 @@ export default {
     async index({ commit, rootState }) {
       const generator = index(rootState.auth);
       try {
+        await store.restored;
         await fetchAll(commit, generator, "setLabels");
         return true;
       } catch (error) {
@@ -77,6 +79,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const result = await read(rootState.auth, id);
+        await store.restored;
         commit("setLabel", { id, label: result });
         return result.id;
       } catch (error) {

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -1,5 +1,5 @@
 import VuexPersistence from "vuex-persist";
-import localforage from "localforage";
+import localForage from "localforage";
 
 const localStorageModules = [
   "auth",
@@ -15,7 +15,7 @@ const localStorageModules = [
 const localForageModules = ["albums", "artists", "genres", "labels"];
 
 export const vuexLocalForage = new VuexPersistence({
-  storage: localforage,
+  storage: localForage,
   asyncStorage: true,
   strictMode: process.env.NODE_ENV !== "production",
   modules: localForageModules,

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -2,7 +2,7 @@ import VuexPersistence from "vuex-persist";
 import localForage from "localforage";
 import debounce from "lodash.debounce";
 
-// A subclass for VuexPersintence to deal with single namespaced modules and large collections
+// A subclass for VuexPersistence to deal with single namespaced modules and large collections
 // Should be provided with a module and an async storage
 // IMPORTANT: This class assumes a lot about the structure of state and mutations available in each module
 // If this structure changes, we inevitably have to update this class

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -2,7 +2,7 @@ import VuexPersistence from "vuex-persist";
 import localForage from "localforage";
 import debounce from "lodash.debounce";
 
-// A subclass for VuexPersintence to deal with single namepaced modules and large collections
+// A subclass for VuexPersintence to deal with single namespaced modules and large collections
 // Should be provided with a module and an async storage
 // IMPORTANT: This class assumes a lot about the structure of state and mutations available in each module
 // If this structure changes, we inevitably have to update this class

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -29,12 +29,12 @@ class VuexPersistentModule extends VuexPersistence {
       saveState: debounce(saveModule, 60000),
     });
 
-    this.upperCaseModule = module;
+    this.capitilizedModule = module;
 
     // Get item from an async storage and commit them back to the store
     this.replaceState = async (
       lowerCaseModule,
-      upperCaseModule,
+      capitilizedModule,
       storage,
       store
     ) => {
@@ -48,7 +48,7 @@ class VuexPersistentModule extends VuexPersistence {
         }
         if (savedState[lowerCaseModule]) {
           store.commit(
-            `${lowerCaseModule}/set${upperCaseModule}`,
+            `${lowerCaseModule}/set${capitilizedModule}`,
             savedState[lowerCaseModule]
           );
         }
@@ -59,7 +59,7 @@ class VuexPersistentModule extends VuexPersistence {
     this.plugin = (store) => {
       store[`${this.key}Restored`] = this.replaceState(
         this.key,
-        this.upperCaseModule,
+        this.capitilizedModule,
         this.storage,
         store
       ).then(() => {

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -1,5 +1,75 @@
 import VuexPersistence from "vuex-persist";
 import localForage from "localforage";
+import debounce from "lodash.debounce";
+
+// A subclass for VuexPersintence to deal with single namepaced modules and large collections
+// Should be provided with a module and an async storage
+// IMPORTANT: This class assumes a lot about the structure of state and mutations available in each module
+// If this structure changes, we inevitably have to update this class
+class VuexPersistentModule extends VuexPersistence {
+  constructor(module, storage) {
+    // Write startLoading and the main collection (as an array) to storage
+    async function saveModule(module, state, storage) {
+      const modifiedState = {
+        startLoading: state[module].startLoading,
+      };
+      modifiedState[module] = Object.values(state[module][module]);
+      await storage.setItem(module, modifiedState);
+    }
+
+    // Set all options in parent class
+    super({
+      storage,
+      asyncStorage: true,
+      modules: [module],
+      key: module,
+      filter: (m) => m.type.substring(0, m.type.indexOf("/")) === module,
+      saveState: debounce(saveModule, 60000),
+    });
+
+    // Get item from an async storage and commit them back to the store
+    this.replaceState = async (module, storage, store) => {
+      const savedState = await storage.getItem(module);
+      if (savedState) {
+        if (savedState.startLoading) {
+          store.commit(`${module}/setStartLoading`, savedState.startLoading);
+        }
+        if (savedState[module]) {
+          store.commit(
+            `${module}/set${module.charAt(0).toUpperCase() + module.slice(1)}`,
+            savedState[module]
+          );
+        }
+      }
+    };
+
+    // Overwrite plugin to use replaceState and set a custom restored prop for each module
+    this.plugin = (store) => {
+      store[`${module}Restored`] = this.replaceState(
+        this.key,
+        this.storage,
+        store
+      ).then(() => {
+        // The subscriber is the same as in VuexPersistence, but we have to add it ourselves since we overwrite the plugin method
+        this.subscriber(store)((mutation, state) => {
+          if (this.filter(mutation)) {
+            this._mutex.enqueue(
+              this.saveState(this.key, this.reducer(state), this.storage)
+            );
+          }
+        });
+        this.subscribed = true;
+      });
+    };
+  }
+}
+
+const plugins = ["albums", "artists", "genres", "labels", "tracks"].map(
+  (module) => {
+    const plugin = new VuexPersistentModule(module, localForage);
+    return plugin.plugin;
+  }
+);
 
 const localStorageModules = [
   "auth",
@@ -12,16 +82,6 @@ const localStorageModules = [
   "users",
   "userSettings",
 ];
-const localForageModules = ["albums", "artists", "genres", "labels"];
-
-export const vuexLocalForage = new VuexPersistence({
-  storage: localForage,
-  asyncStorage: true,
-  strictMode: process.env.NODE_ENV !== "production",
-  modules: localForageModules,
-  filter: (m) =>
-    localForageModules.includes(m.type.substring(0, m.type.indexOf("/"))),
-});
 
 export const vuexLocalStorage = new VuexPersistence({
   storage: window.localStorage,
@@ -30,3 +90,7 @@ export const vuexLocalStorage = new VuexPersistence({
   filter: (m) =>
     localStorageModules.includes(m.type.substring(0, m.type.indexOf("/"))),
 });
+
+plugins.push(vuexLocalStorage.plugin);
+
+export default plugins;

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -64,12 +64,17 @@ class VuexPersistentModule extends VuexPersistence {
   }
 }
 
-const plugins = ["albums", "artists", "genres", "labels", "tracks"].map(
-  (module) => {
-    const plugin = new VuexPersistentModule(module, localForage);
-    return plugin.plugin;
-  }
-);
+const plugins = [
+  "albums",
+  "artists",
+  "genres",
+  "labels",
+  "plays",
+  "tracks",
+].map((module) => {
+  const plugin = new VuexPersistentModule(module, localForage);
+  return plugin.plugin;
+});
 
 const localStorageModules = [
   "auth",

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -1,0 +1,32 @@
+import VuexPersistence from "vuex-persist";
+import localforage from "localforage";
+
+const localStorageModules = [
+  "auth",
+  "codecConversions",
+  "codecs",
+  "coverFilenames",
+  "imageTypes",
+  "locations",
+  "rescan",
+  "users",
+  "userSettings",
+];
+const localForageModules = ["albums", "artists", "genres", "labels"];
+
+export const vuexLocalForage = new VuexPersistence({
+  storage: localforage,
+  asyncStorage: true,
+  strictMode: process.env.NODE_ENV !== "production",
+  modules: localForageModules,
+  filter: (m) =>
+    localForageModules.includes(m.type.substring(0, m.type.indexOf("/"))),
+});
+
+export const vuexLocalStorage = new VuexPersistence({
+  storage: window.localStorage,
+  strictMode: process.env.NODE_ENV !== "production",
+  modules: localStorageModules,
+  filter: (m) =>
+    localStorageModules.includes(m.type.substring(0, m.type.indexOf("/"))),
+});

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -57,7 +57,7 @@ class VuexPersistentModule extends VuexPersistence {
 
     // Overwrite plugin to use replaceState and set a custom restored prop for each module
     this.plugin = (store) => {
-      store[`${module}Restored`] = this.replaceState(
+      store[`${this.key}Restored`] = this.replaceState(
         this.key,
         this.upperCaseModule,
         this.storage,

--- a/src/store/plays.js
+++ b/src/store/plays.js
@@ -1,6 +1,5 @@
 import { index, create } from "../api/plays";
 import { fetchAll } from "./actions";
-import store from "./store";
 
 export default {
   namespaced: true,
@@ -45,7 +44,7 @@ export default {
     async index({ commit, rootState }) {
       const generator = index(rootState.auth);
       try {
-        await store.playsRestored;
+        await this.playsRestored;
         await fetchAll(commit, generator, "setPlays");
         return true;
       } catch (error) {

--- a/src/store/plays.js
+++ b/src/store/plays.js
@@ -1,5 +1,6 @@
 import { index, create } from "../api/plays";
 import { fetchAll } from "./actions";
+import store from "./store";
 
 export default {
   namespaced: true,
@@ -44,6 +45,7 @@ export default {
     async index({ commit, rootState }) {
       const generator = index(rootState.auth);
       try {
+        await store.playsRestored;
         await fetchAll(commit, generator, "setPlays");
         return true;
       } catch (error) {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import Vuex from "vuex";
-import { vuexLocalForage, vuexLocalStorage } from "./persistence";
+import persistencePlugins, { vuexLocalStorage } from "./persistence";
 import albums from "./albums";
 import artists from "./artists";
 import auth from "./auth";
@@ -36,11 +36,11 @@ const mutations = {
 };
 
 if (process.env.NODE_ENV !== "production") {
-  mutations.RESTORE_MUTATION = vuexLocalForage.RESTORE_MUTATION;
+  mutations.RESTORE_MUTATION = vuexLocalStorage.RESTORE_MUTATION;
 }
 
 export default new Vuex.Store({
-  plugins: [vuexLocalForage.plugin, vuexLocalStorage.plugin],
+  plugins: persistencePlugins,
   strict: process.env.NODE_ENV !== "production",
   modules: {
     albums,

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import Vuex from "vuex";
-import createPersistedState from "vuex-persistedstate";
+import { vuexLocalForage, vuexLocalStorage } from "./persistence";
 import albums from "./albums";
 import artists from "./artists";
 import auth from "./auth";
@@ -21,11 +21,7 @@ import userSettings from "./user_settings";
 Vue.use(Vuex);
 
 export default new Vuex.Store({
-  plugins: [
-    createPersistedState({
-      paths: ["auth", "userSettings"],
-    }),
-  ],
+  plugins: [vuexLocalForage.plugin, vuexLocalStorage.plugin],
   strict: process.env.NODE_ENV !== "production",
   modules: {
     albums,

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -20,6 +20,25 @@ import userSettings from "./user_settings";
 
 Vue.use(Vuex);
 
+const mutations = {
+  addError(state, error) {
+    if (error.unauthorized) {
+      this.commit("auth/logout");
+    }
+    state.errors.push(error);
+  },
+  clearErrors(state) {
+    state.errors = [];
+  },
+  updateCurrentDay(state) {
+    state.currentDay = new Date().setHours(0, 0, 0, 0);
+  },
+};
+
+if (process.env.NODE_ENV !== "production") {
+  mutations.RESTORE_MUTATION = vuexLocalForage.RESTORE_MUTATION;
+}
+
 export default new Vuex.Store({
   plugins: [vuexLocalForage.plugin, vuexLocalStorage.plugin],
   strict: process.env.NODE_ENV !== "production",
@@ -45,20 +64,7 @@ export default new Vuex.Store({
     errors: [],
     currentDay: new Date().setHours(0, 0, 0, 0),
   },
-  mutations: {
-    addError(state, error) {
-      if (error.unauthorized) {
-        this.commit("auth/logout");
-      }
-      state.errors.push(error);
-    },
-    clearErrors(state) {
-      state.errors = [];
-    },
-    updateCurrentDay(state) {
-      state.currentDay = new Date().setHours(0, 0, 0, 0);
-    },
-  },
+  mutations,
   actions: {},
   getters: {
     numberOfFlaggedItems(state, getters) {

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -3,6 +3,7 @@ import { index, create, destroy, update, read, merge } from "../api/tracks";
 import { fetchAll } from "./actions";
 import { compareTracks } from "../comparators";
 import { TracksScope } from "../api/scopes";
+import store from "./store";
 
 export default {
   namespaced: true,
@@ -101,6 +102,7 @@ export default {
     async index({ commit, rootState }, scope = new TracksScope()) {
       const generator = index(rootState.auth, scope);
       try {
+        await store.tracksRestored;
         await fetchAll(commit, generator, "setTracks", scope);
         return true;
       } catch (error) {
@@ -121,6 +123,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const track = await read(rootState.auth, id);
+        await store.tracksRestored;
         commit("setTrack", { id, track });
         return true;
       } catch (error) {

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -3,7 +3,6 @@ import { index, create, destroy, update, read, merge } from "../api/tracks";
 import { fetchAll } from "./actions";
 import { compareTracks } from "../comparators";
 import { TracksScope } from "../api/scopes";
-import store from "./store";
 
 export default {
   namespaced: true,
@@ -102,7 +101,7 @@ export default {
     async index({ commit, rootState }, scope = new TracksScope()) {
       const generator = index(rootState.auth, scope);
       try {
-        await store.tracksRestored;
+        await this.tracksRestored;
         await fetchAll(commit, generator, "setTracks", scope);
         return true;
       } catch (error) {
@@ -123,7 +122,7 @@ export default {
     async read({ commit, rootState }, id) {
       try {
         const track = await read(rootState.auth, id);
-        await store.tracksRestored;
+        await this.tracksRestored;
         commit("setTrack", { id, track });
         return true;
       } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3983,6 +3983,11 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
+flatted@^3.0.5:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
+  integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -4570,6 +4575,11 @@ ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -5210,6 +5220,13 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -5255,6 +5272,13 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+localforage@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.9.0.tgz#f3e4d32a8300b362b4634cc4e066d9d00d2f09d1"
+  integrity sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -7368,11 +7392,6 @@ shelljs@^0.8.3:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shvl@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.3.tgz#eb4bd37644f5684bba1fc52c3010c96fb5e6afd1"
-  integrity sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==
-
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
@@ -8426,13 +8445,13 @@ vuetify@^2.5.6:
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.5.6.tgz#9cbb1eacece6c42028216312b9be23e35a7f5cf4"
   integrity sha512-2T8ML5PYuJ/AdMVH3ZIvzHnsM0nX8t4Xzj+0HFFGfLT7jLlptCFpG+JE8+kyrgGZlbUgulyOwCUu8hJkVsReFA==
 
-vuex-persistedstate@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-3.2.0.tgz#41d3ea304404769ac653ec020de80c95ce16243d"
-  integrity sha512-1Q4zV9cNaJtl59jN6rXbndemEtXKywZr0OFZnqgpYdwvdyy+64KNsEltKldQW+i03st5LuDwHsdOEevXIZUgdg==
+vuex-persist@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/vuex-persist/-/vuex-persist-3.1.3.tgz#518c722a2ca3026bcee5732f99d24f75cee0f3b6"
+  integrity sha512-QWOpP4SxmJDC5Y1+0+Yl/F4n7z27syd1St/oP+IYCGe0X0GFio0Zan6kngZFufdIhJm+5dFGDo3VG5kdkCGeRQ==
   dependencies:
     deepmerge "^4.2.2"
-    shvl "^2.0.2"
+    flatted "^3.0.5"
 
 vuex@^3.6.2:
   version "3.6.2"


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

# Description
Fix #39
This uses the same idea as #48 but with a few differences.

## Different caches
We store data in two places: localStorage and localForage. localStorage is prefered since it is synchronous, so it is used for most modules. This way we have **instant** access to data from those modules

The main collections that are to big to be stored inside localStorage and are stored in localForage.
I've added a subclass to `VuexPersistence` that allows us to save and restore data in a memory safe way. (VuexPersist would try and merge the existing store with the savedStore, which would cause huge spikes in memory usage), we can now use the mutations within each module.

## Router isn't blocked
I've placed the `await store.restored` before we would commit something in any of the modules that are stored async. Since we overwrite the way this value is set, we have a separate restored for each module that is stored async.

This way we can already render the page while data is loaded from localForage. A user might experience a 2-3 sec delay before the page is populated with data, but that feels very acceptable.

## Filter mutations
Just as in #414. We only set a cache when something inside of the modules in the cache is changed.
This makes that commits in the player don't have any effect on the cache.

## Debounced `saveState`
The methods that are stored in localForage have their `saveState` wrapped in a debounce with a wait time of a minute. 
If a user is editing, loading data, it doesn't make much sense to save the state after every mutation. Since we don't use these values directly, the user should not notice this. 
(There is a slim chance that the user closes the tab before the data was stored, but if that is the case, the user will get the updated data soon after loading the app.)

# How Has This Been Tested?

Tested by refreshing quite a bit during the course of a day in both Chrome and FF.

The usual memory usage might spike up to 200MB when restoring or saveing the cache from localForage and settled to around 80MB - 120MB after this.