### PR TITLE
Provide image fallback if image is unavailable

### DIFF
--- a/src/components/AlbumCard.vue
+++ b/src/components/AlbumCard.vue
@@ -1,7 +1,17 @@
 <template>
   <VCard :to="{ name: 'album', params: { id: album.id } }">
-    <VImg :aspect-ratio="1" :src="album.image500" v-if="album.image500" />
-    <VImg :aspect-ratio="1" :src="album.image" v-else-if="album.image" />
+    <VImg
+      :aspect-ratio="1"
+      :src="album.image500"
+      v-if="album.image500 && !imageUnavailable"
+      @error="setImageUnavailable"
+    />
+    <VImg
+      :aspect-ratio="1"
+      :src="album.image"
+      v-else-if="album.image && !imageUnavailable"
+      @error="setImageUnavailable"
+    />
     <VImg
       :aspect-ratio="1"
       :src="require('@mdi/svg/svg/album.svg')"
@@ -45,6 +55,11 @@ export default {
       required: false,
     },
   },
+  data() {
+    return {
+      imageUnavailable: false,
+    };
+  },
   computed: {
     catalogueNumber() {
       if (this.labelForCatNr) {
@@ -61,6 +76,11 @@ export default {
         full_title += ` ${this.album.edition_description}`;
       }
       return full_title;
+    },
+  },
+  methods: {
+    setImageUnavailable() {
+      this.imageUnavailable = true;
     },
   },
 };

--- a/src/components/ArtistCard.vue
+++ b/src/components/ArtistCard.vue
@@ -1,7 +1,17 @@
 <template>
   <VCard :to="{ name: 'artist', params: { id: artist.id } }">
-    <VImg :aspect-ratio="1" :src="artist.image500" v-if="artist.image500" />
-    <VImg :aspect-ratio="1" :src="artist.image" v-else-if="artist.image" />
+    <VImg
+      :aspect-ratio="1"
+      :src="artist.image500"
+      v-if="artist.image500 && !imageUnavailable"
+      @error="setImageUnavailable"
+    />
+    <VImg
+      :aspect-ratio="1"
+      :src="artist.image"
+      v-else-if="artist.image"
+      @error="setImageUnavailable"
+    />
     <VImg
       :aspect-ratio="1"
       :src="require('@mdi/svg/svg/account-music.svg')"
@@ -25,6 +35,16 @@ export default {
   components: { ArtistActions },
   props: {
     artist: { type: Object, required: true },
+  },
+  data() {
+    return {
+      imageUnavailable: false,
+    };
+  },
+  methods: {
+    setImageUnavailable() {
+      this.imageUnavailable = true;
+    },
   },
 };
 </script>

--- a/src/views/albums/Album.vue
+++ b/src/views/albums/Album.vue
@@ -2,10 +2,22 @@
   <VContainer fluid v-if="album">
     <vue-headful :title="album.title + ' | Accentor'" />
     <VRow>
-      <VCol lg="3" md="4" sm="6" v-if="album.image500" cols="12">
+      <VCol
+        lg="3"
+        md="4"
+        sm="6"
+        v-if="album.image500 && !imageUnavailable"
+        cols="12"
+      >
         <VImg :src="album.image500" class="elevation-3" />
       </VCol>
-      <VCol lg="3" md="4" sm="6" v-else-if="album.image" cols="12">
+      <VCol
+        lg="3"
+        md="4"
+        sm="6"
+        v-else-if="album.image && !imageUnavailable"
+        cols="12"
+      >
         <VImg :src="album.image" class="elevation-3" />
       </VCol>
       <VCol lg="9" md="8" sm="6" cols="12">
@@ -58,6 +70,11 @@ import AlbumArtists from "../../components/AlbumArtists";
 export default {
   name: "Album",
   components: { AlbumArtists, TracksTable, AlbumActions },
+  data() {
+    return {
+      imageUnavailable: false,
+    };
+  },
   watch: {
     album: function () {
       if (this.album === undefined) {
@@ -80,6 +97,11 @@ export default {
       return this.album.album_labels.filter(
         (al) => `${al.label_id}` in this.labels
       );
+    },
+  },
+  methods: {
+    setImageUnavailable() {
+      this.imageUnavailable = true;
     },
   },
 };

--- a/src/views/artists/Artist.vue
+++ b/src/views/artists/Artist.vue
@@ -2,10 +2,22 @@
   <VContainer fluid v-if="artist">
     <vue-headful :title="artist.name + ' | Accentor'" />
     <VRow>
-      <VCol lg="3" md="4" sm="6" v-if="artist.image500" cols="12">
+      <VCol
+        lg="3"
+        md="4"
+        sm="6"
+        v-if="artist.image500 && !imageUnavailable"
+        cols="12"
+      >
         <VImg :src="artist.image500" class="elevation-3" />
       </VCol>
-      <VCol lg="3" md="4" sm="6" v-else-if="artist.image" cols="12">
+      <VCol
+        lg="3"
+        md="4"
+        sm="6"
+        v-else-if="artist.image && !imageUnavailable"
+        cols="12"
+      >
         <VImg :src="artist.image" class="elevation-3" />
       </VCol>
       <VCol lg="9" md="8" sm="6" cols="12">
@@ -55,6 +67,11 @@ export default {
     AlbumCard,
     ArtistActions,
   },
+  data() {
+    return {
+      imageUnavailable: false,
+    };
+  },
   watch: {
     artist: function () {
       if (this.artist === undefined) {
@@ -77,6 +94,11 @@ export default {
     },
     artist: function () {
       return this.artists[this.$route.params.id];
+    },
+  },
+  methods: {
+    setImageUnavailable() {
+      this.imageUnavailable = true;
     },
   },
 };


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

# Description

re #416 
If the API is unavailable (or returns an error of any kind) we should fall back the icon or not try to display the image.

The user is not notified of this error - since they probably will not care.
When the component is destroyed and recreated the `imageUnavailable` prop will be reset and the front-end will try to get the image again

