### PR TITLE
Fix optional chaining in metainfo

### DIFF
--- a/src/views/albums/Album.vue
+++ b/src/views/albums/Album.vue
@@ -70,7 +70,7 @@ export default {
   name: "Album",
   components: { AlbumArtists, TracksTable, AlbumActions },
   metaInfo() {
-    return { title: this.album.title };
+    return { title: this.album?.title };
   },
   data() {
     return {

--- a/src/views/albums/EditAlbum.vue
+++ b/src/views/albums/EditAlbum.vue
@@ -11,7 +11,7 @@ import AlbumForm from "../../components/AlbumForm";
 export default {
   name: "EditAlbum",
   metaInfo() {
-    return { title: this.$t("page-titles.edit", { obj: this.album.title }) };
+    return { title: this.$t("page-titles.edit", { obj: this.album?.title }) };
   },
   components: { AlbumForm },
   computed: {

--- a/src/views/artists/Artist.vue
+++ b/src/views/artists/Artist.vue
@@ -62,7 +62,7 @@ import TracksTable from "../../components/TracksTable";
 export default {
   name: "Artist",
   metaInfo() {
-    return { title: this.artist.name };
+    return { title: this.artist?.name };
   },
   components: {
     TracksTable,

--- a/src/views/artists/EditArtist.vue
+++ b/src/views/artists/EditArtist.vue
@@ -12,7 +12,7 @@ export default {
   name: "EditArtist",
   components: { ArtistForm },
   metaInfo() {
-    return { title: this.$t("page-titles.edit", { obj: this.artist.name }) };
+    return { title: this.$t("page-titles.edit", { obj: this.artist?.name }) };
   },
   computed: {
     ...mapState("artists", ["artists"]),

--- a/src/views/genres/EditGenre.vue
+++ b/src/views/genres/EditGenre.vue
@@ -24,7 +24,7 @@ import { mapActions, mapState } from "vuex";
 export default {
   name: "EditGenre",
   metaInfo() {
-    return { title: this.$t("page-titles.edit", { obj: this.genre.name }) };
+    return { title: this.$t("page-titles.edit", { obj: this.genre?.name }) };
   },
   data() {
     return {

--- a/src/views/genres/Genre.vue
+++ b/src/views/genres/Genre.vue
@@ -27,7 +27,7 @@ export default {
   name: "Genre",
   components: { GenreActions, TracksTable },
   metaInfo() {
-    return { title: this.genre.name };
+    return { title: this.genre?.name };
   },
   watch: {
     genre: function () {


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

## Description

A user can visit a page where the object doesn't exist yet. Currently an error is thrown, since `name` or `title` can't be accessed. 
This PR fixes that by optional chaining.

