### PR TITLE
Add a key to each section of MassEditDialog

### DIFF
--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -35,6 +35,7 @@
             <VContainer
               fluid
               v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
+              key="showReviewComments"
             >
               <VRow dense>
                 <VCol cols="12">
@@ -83,7 +84,7 @@
             <VDivider
               v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
             />
-            <VContainer fluid>
+            <VContainer fluid key="increaseTrackNumbers">
               <VRow dense>
                 <VCol cols="12" sm="6">
                   <VCheckbox v-model="number.enabled">
@@ -107,7 +108,7 @@
               </VRow>
             </VContainer>
             <VDivider />
-            <VContainer fluid>
+            <VContainer fluid key="searchAndReplaceTitle">
               <VRow dense>
                 <VCol cols="12" sm="6">
                   <VCheckbox v-model="titleReplacement.enabled">
@@ -142,7 +143,7 @@
               </VRow>
             </VContainer>
             <VDivider />
-            <VContainer fluid>
+            <VContainer fluid key="setAlbum">
               <VRow dense>
                 <VCol cols="12" sm="6">
                   <VCheckbox v-model="album.enabled">
@@ -169,7 +170,7 @@
               </VRow>
             </VContainer>
             <VDivider />
-            <VContainer fluid>
+            <VContainer fluid key="changeGenres">
               <VRow dense>
                 <VCol cols="12" sm="6">
                   <VCheckbox v-model="changeGenres.enabled">
@@ -209,7 +210,7 @@
               </VRow>
             </VContainer>
             <VDivider />
-            <VContainer fluid>
+            <VContainer fluid key="changeArtists">
               <VRow dense>
                 <VCol cols="12" sm="6">
                   <VCheckbox v-model="changeArtists.enabled">
@@ -247,6 +248,7 @@
             <VContainer
               fluid
               v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
+              key="clearReviewComments"
             >
               <VRow dense>
                 <VCol cols="12" sm="6">


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

# Description
Fix #507 
By adding a key, se help vue distinguish between the sections of the dialog. The keys are just simple string, since we just need to distinguish the sections with the same selection of tracks

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in local dev env by reproducing issue behaviour and verifying the expected behaviour is returned.
- [x] Tested where switching selections of tracks still produces the expected behaviour. 
