### PR TITLE
Show review comments count in MassEditDialog

### DIFF
--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -34,7 +34,7 @@
             <Errors />
             <VContainer
               fluid
-              v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
+              v-if="tracksWithReviewComments.length > 0"
               key="showReviewComments"
             >
               <VRow dense>
@@ -45,13 +45,8 @@
                         {{
                           $tc(
                             "music.flag.show",
-                            tracks.filter((t) => t.review_comment !== null)
-                              .length,
-                            {
-                              count: tracks.filter(
-                                (t) => t.review_comment !== null
-                              ).length,
-                            }
+                            tracksWithReviewComments.length,
+                            { count: tracksWithReviewComments.length }
                           )
                         }}
                       </span>
@@ -67,12 +62,7 @@
                     icon="mdi-flag"
                   >
                     <table class="review-comment-table">
-                      <tr
-                        v-for="t of tracks.filter(
-                          (tr) => tr.review_comment !== null
-                        )"
-                        :key="t.id"
-                      >
+                      <tr v-for="t of tracksWithReviewComments" :key="t.id">
                         <td class="text-right">
                           <strong>{{ t.number }}</strong>
                         </td>
@@ -86,9 +76,7 @@
                 </VCol>
               </VRow>
             </VContainer>
-            <VDivider
-              v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
-            />
+            <VDivider v-if="tracksWithReviewComments.length > 0" />
             <VContainer fluid key="increaseTrackNumbers">
               <VRow dense>
                 <VCol cols="12" sm="6">
@@ -247,12 +235,10 @@
                 {{ $t("music.artist.add") }}
               </VBtn>
             </VContainer>
-            <VDivider
-              v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
-            />
+            <VDivider v-if="tracksWithReviewComments.length > 0" />
             <VContainer
               fluid
-              v-if="tracks.filter((t) => t.review_comment !== null).length > 0"
+              v-if="tracksWithReviewComments.length > 0"
               key="clearReviewComments"
             >
               <VRow dense>
@@ -263,8 +249,7 @@
                         {{
                           $tc(
                             "music.flag.clear",
-                            tracks.filter((t) => t.review_comment !== null)
-                              .length
+                            tracksWithReviewComments.length
                           )
                         }}
                       </span>
@@ -340,6 +325,9 @@ export default {
     ...mapGetters("genres", {
       sortedGenres: "genresByName",
     }),
+    tracksWithReviewComments: () => {
+      this.tracks.filter((t) => t.review_comment !== null);
+    },
     rules: function () {
       const rules = {
         genre: [],

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -46,7 +46,12 @@
                           $tc(
                             "music.flag.show",
                             tracks.filter((t) => t.review_comment !== null)
-                              .length
+                              .length,
+                            {
+                              count: tracks.filter(
+                                (t) => t.review_comment !== null
+                              ).length,
+                            }
                           )
                         }}
                       </span>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -263,7 +263,7 @@
 			"comment": "Comment",
 			"for-review": "Flag for review",
 			"review-comments": "Review comments | Review comment | Review comments",
-			"show": "Show review comments | Show review comment | Show review comments"
+			"show": "Show review comments | Show review comment | Show {count} review comments"
 		},
 		"flags": "Flags | Flag | Flags",
 		"genre-s": "Genre(s)",


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

## Description

A mod/admin currently has no simply way to know how many review comments there are for their selection of tracks, except for showing them and (trying to) count them. By giving the explicit number they can compare this value to the amount of tracks they are editing.

Since the same filter (`tracks.filter((t) => t.review_comment !== null)`) was now used 8 times, I extracted this to a computed value

# How Has This Been Tested?


- [x] Quick local server to verify everything is rendered ok
