### PR TITLE
Fix computed value in MassEditDialog

### DIFF
--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -325,8 +325,8 @@ export default {
     ...mapGetters("genres", {
       sortedGenres: "genresByName",
     }),
-    tracksWithReviewComments: () => {
-      this.tracks.filter((t) => t.review_comment !== null);
+    tracksWithReviewComments() {
+      return this.tracks.filter((t) => t.review_comment !== null);
     },
     rules: function () {
       const rules = {


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

## Description
Fix a side-effect from #516 .
The extracted computed value didn't correctly return its value. Causing the whole component to break


