### PR TITLE
Allow the album to be missing in the TracksTable

### DIFF
--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -77,7 +77,7 @@
       </template>
       <template v-slot:item.album_id="props">
         <RouterLink :to="{ name: 'album', params: { id: props.value } }">
-          {{ albums[props.value].title }}
+          {{ albums[props.value] ? albums[props.value].title : "" }}
         </RouterLink>
       </template>
       <template v-slot:item.track_artists="props">


### PR DESCRIPTION
<!--
Thanks for contributing to Accentor!
Make sure all GitHub actions (lint & build) will pass and fill out the template.

You can tag your PR with the relevant tags and request a review from someone of the team.
If any changes to your PR are necessary, we will ask for them through the review process.
 -->

## Description

Since we can't know which resources will be loaded first, it could always be that tracks are loaded and displayed before their album is loaded. This currently prints a lot of errors to the console, but should just fail gracefully (as we have done for Album artists, album labels, track genres, ...)
