### PR TITLE
Make sure edit buttons still work after a scope load

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,5 +1,9 @@
 export async function fetchAll(commit, generator, commitAction, scope = null) {
-  commit("setStartLoading");
+  // If there is no scope present, we prepare for removing old items
+  // later (this also influences editability of items)
+  if (scope === null) {
+    commit("setStartLoading");
+  }
   let done = false;
   let results = [];
   let counter = 0;


### PR DESCRIPTION
Due to `setStartLoading` being called even when a scope is passed, the timestamp we use to check if items can be edited changes for all items, even though only a few items will be loaded. This makes sure `setStartLoading` is only called if we are doing a full load.