### PR TITLE
Make column widths and alignment in track table a little nicer

### DIFF
--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -125,7 +125,7 @@ export default {
         text: "#",
         value: "number",
         sortable: false,
-        align: "center",
+        align: "end",
         width: "1px",
       },
       {
@@ -138,6 +138,7 @@ export default {
         value: "length",
         sortable: false,
         align: "end",
+        width: "1px",
       },
       {
         text: this.$tc("music.albums", 1),
@@ -159,12 +160,14 @@ export default {
         value: "play_count",
         sortable: false,
         align: "end",
+        width: "1px",
       },
       {
         text: this.$t("common.actions"),
         value: "actions",
         sortable: false,
         align: "end",
+        width: "1px",
       },
     ];
     if (!this.showAlbum) {


### PR DESCRIPTION
This aligns the track number to the right (generally recommended for numbers, allows easier comparison) and makes sure the end alignment for the plays column doesn't look too weird (at least it looked a little weird to me).

Before:
![screenshot_2021-07-14-134616](https://user-images.githubusercontent.com/42220376/125617353-9a1f925c-d57c-4d93-be26-8b3fea5ec424.png)

After:
![screenshot_2021-07-14-134727](https://user-images.githubusercontent.com/42220376/125617355-4e20d83c-5454-4a7a-8101-cd51081d3063.png)

