### PR TITLE
Limit draggable tracks in Player to handle

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -3,14 +3,18 @@
     <audio ref="audio" @error="onAudioError" />
     <div class="tracks-list-container" v-if="open">
       <table class="tracks-list">
-        <Draggable tag="tbody" @end="updatePlaylist">
+        <Draggable
+          tag="tbody"
+          @end="updatePlaylist"
+          handle="[data-draggable=handle]"
+        >
           <tr
             v-for="(track, index) of playlistTracks"
             :key="track.id"
             class="track"
           >
             <td class="px-0 icon">
-              <VBtn small icon text class="ma-2">
+              <VBtn small icon text class="ma-2" data-draggable="handle">
                 <VIcon>mdi-drag-horizontal-variant</VIcon>
               </VBtn>
             </td>


### PR DESCRIPTION
A user can currently drag the whole row to reorder the playlist. However, on touchscreens this break usage of the playlist: any attempt to scroll (both horizontal and vertical) will be seen as dragging.
I've limited the ability to drag to the handle provided.