### PR TITLE
Remove rescan from localstorage

### DIFF
--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -96,7 +96,6 @@ const localStorageModules = [
   "coverFilenames",
   "imageTypes",
   "locations",
-  "rescan",
   "users",
   "userSettings",
 ];


### PR DESCRIPTION
Fixes #534 
I've simply removed the rescan module from the modules that are stored in localStorage - since it is very temporary information, it shouldn't matter whether this is cached or not.