### PR TITLE
Improve grid views on xs screens

### DIFF
--- a/src/components/AlbumActions.vue
+++ b/src/components/AlbumActions.vue
@@ -7,7 +7,7 @@
             @click.stop.prevent="startTracks"
             :disabled="playableTracks.length === 0"
             color="primary"
-            class="ma-sm-2"
+            class="ml-0 ma-1 ma-sm-2"
             text
             icon
             small
@@ -25,7 +25,7 @@
             @click.stop.prevent="addTracks"
             :disabled="playableTracks.length === 0"
             color="success"
-            class="ma-sm-2"
+            class="ma-1 ma-sm-2"
             text
             icon
             small
@@ -49,7 +49,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ma-sm-2"
+            class="ma-1 ma-sm-2"
             text
             icon
             small
@@ -67,7 +67,7 @@
             @click.stop.prevent="deleteAlbum"
             :disabled="album.loaded < startLoading"
             color="danger"
-            class="ma-sm-2"
+            class="mr-0 ma-1 ma-sm-2"
             text
             href="#"
             icon

--- a/src/components/AlbumActions.vue
+++ b/src/components/AlbumActions.vue
@@ -7,7 +7,7 @@
             @click.stop.prevent="startTracks"
             :disabled="playableTracks.length === 0"
             color="primary"
-            class="ma-2"
+            class="ma-sm-2"
             text
             icon
             small
@@ -25,7 +25,7 @@
             @click.stop.prevent="addTracks"
             :disabled="playableTracks.length === 0"
             color="success"
-            class="ma-2"
+            class="ma-sm-2"
             text
             icon
             small
@@ -49,7 +49,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ma-2"
+            class="ma-sm-2"
             text
             icon
             small
@@ -67,7 +67,7 @@
             @click.stop.prevent="deleteAlbum"
             :disabled="album.loaded < startLoading"
             color="danger"
-            class="ma-2"
+            class="ma-sm-2"
             text
             href="#"
             icon

--- a/src/components/ArtistActions.vue
+++ b/src/components/ArtistActions.vue
@@ -12,7 +12,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ma-sm-2"
+            class="ml-0 ma-1 ma-sm-2"
             text
             icon
             small
@@ -38,7 +38,7 @@
             @click.stop.prevent="deleteArtist"
             :disabled="waitingForReload"
             color="danger"
-            class="ma-sm-2"
+            class="mr-0 ma-1 ma-sm-2"
             href="#"
             text
             icon

--- a/src/components/ArtistActions.vue
+++ b/src/components/ArtistActions.vue
@@ -12,7 +12,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ma-2"
+            class="ma-sm-2"
             text
             icon
             small
@@ -38,7 +38,7 @@
             @click.stop.prevent="deleteArtist"
             :disabled="waitingForReload"
             color="danger"
-            class="ma-2"
+            class="ma-sm-2"
             href="#"
             text
             icon

--- a/src/components/ArtistMergeDialog.vue
+++ b/src/components/ArtistMergeDialog.vue
@@ -10,7 +10,7 @@
         v-on="on"
         :disabled="disabled"
         @click.stop.prevent
-        class="ma-2"
+        class="ma-sm-2"
         color="edit"
         text
         icon

--- a/src/components/ArtistMergeDialog.vue
+++ b/src/components/ArtistMergeDialog.vue
@@ -10,7 +10,7 @@
         v-on="on"
         :disabled="disabled"
         @click.stop.prevent
-        class="ma-sm-2"
+        class="ma-1 ma-sm-2"
         color="edit"
         text
         icon

--- a/src/components/EditReviewComment.vue
+++ b/src/components/EditReviewComment.vue
@@ -1,7 +1,7 @@
 <template>
   <VBtn
     color="flag"
-    class="ma-sm-1"
+    class="ma-1 ma-sm-2"
     text
     icon
     small

--- a/src/components/EditReviewComment.vue
+++ b/src/components/EditReviewComment.vue
@@ -1,7 +1,7 @@
 <template>
   <VBtn
     color="flag"
-    class="ma-1"
+    class="ma-sm-1"
     text
     icon
     small

--- a/src/components/GenreActions.vue
+++ b/src/components/GenreActions.vue
@@ -11,7 +11,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ma-sm-2"
+            class="ml-0 ma-1 ma-sm-2"
             text
             icon
             small
@@ -37,7 +37,7 @@
             @click.stop.prevent="deleteGenre"
             :disabled="waitingForReload"
             color="danger"
-            class="ma-sm-2"
+            class="mr-0 ma-1 ma-sm-2"
             href="#"
             text
             icon

--- a/src/components/GenreActions.vue
+++ b/src/components/GenreActions.vue
@@ -11,7 +11,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ma-2"
+            class="ma-sm-2"
             text
             icon
             small
@@ -37,7 +37,7 @@
             @click.stop.prevent="deleteGenre"
             :disabled="waitingForReload"
             color="danger"
-            class="ma-2"
+            class="ma-sm-2"
             href="#"
             text
             icon

--- a/src/components/GenreMergeDialog.vue
+++ b/src/components/GenreMergeDialog.vue
@@ -10,7 +10,7 @@
         v-on="on"
         :disabled="disabled"
         @click.stop.prevent
-        class="ma-2"
+        class="ma-sm-2"
         color="edit"
         text
         icon

--- a/src/components/GenreMergeDialog.vue
+++ b/src/components/GenreMergeDialog.vue
@@ -10,7 +10,7 @@
         v-on="on"
         :disabled="disabled"
         @click.stop.prevent
-        class="ma-sm-2"
+        class="ma-1 ma-sm-2"
         color="edit"
         text
         icon

--- a/src/components/LabelActions.vue
+++ b/src/components/LabelActions.vue
@@ -11,7 +11,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ma-sm-2"
+            class="ml-0 ma-1 ma-sm-2"
             text
             icon
             small
@@ -37,7 +37,7 @@
             @click.stop.prevent="deleteLabel"
             :disabled="waitingForReload"
             color="danger"
-            class="ma-sm-2"
+            class="mr-0 ma-1 ma-sm-2"
             href="#"
             text
             icon

--- a/src/components/LabelActions.vue
+++ b/src/components/LabelActions.vue
@@ -11,7 +11,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ma-2"
+            class="ma-sm-2"
             text
             icon
             small
@@ -37,7 +37,7 @@
             @click.stop.prevent="deleteLabel"
             :disabled="waitingForReload"
             color="danger"
-            class="ma-2"
+            class="ma-sm-2"
             href="#"
             text
             icon

--- a/src/components/LabelMergeDialog.vue
+++ b/src/components/LabelMergeDialog.vue
@@ -10,7 +10,7 @@
         v-on="on"
         :disabled="disabled"
         @click.stop.prevent
-        class="ma-2"
+        class="ma-sm-2"
         color="edit"
         text
         icon

--- a/src/components/LabelMergeDialog.vue
+++ b/src/components/LabelMergeDialog.vue
@@ -10,7 +10,7 @@
         v-on="on"
         :disabled="disabled"
         @click.stop.prevent
-        class="ma-sm-2"
+        class="ma-1 ma-sm-2"
         color="edit"
         text
         icon

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -22,7 +22,7 @@
               md="4"
               sm="6"
               xl="2"
-              cols="12"
+              cols="6"
             >
               <AlbumCard :album="item" />
             </VCol>
@@ -54,7 +54,7 @@
               md="4"
               sm="6"
               xl="2"
-              cols="12"
+              cols="6"
             >
               <AlbumCard :album="item" />
             </VCol>
@@ -86,7 +86,7 @@
               md="4"
               sm="6"
               xl="2"
-              cols="12"
+              cols="6"
             >
               <ArtistCard :artist="item" />
             </VCol>
@@ -121,7 +121,7 @@
               md="4"
               sm="6"
               xl="2"
-              cols="12"
+              cols="6"
             >
               <AlbumCard :album="item" />
             </VCol>
@@ -154,7 +154,7 @@
               md="4"
               sm="6"
               xl="2"
-              cols="12"
+              cols="6"
             >
               <AlbumCard :album="item" />
             </VCol>
@@ -186,7 +186,7 @@
               md="4"
               sm="6"
               xl="2"
-              cols="12"
+              cols="6"
             >
               <ArtistCard :artist="item" />
             </VCol>

--- a/src/views/albums/Albums.vue
+++ b/src/views/albums/Albums.vue
@@ -41,7 +41,7 @@
             md="4"
             sm="6"
             xl="2"
-            cols="12"
+            cols="6"
           >
             <AlbumCard :album="item" />
           </VCol>

--- a/src/views/artists/Artist.vue
+++ b/src/views/artists/Artist.vue
@@ -36,7 +36,7 @@
         sm="6"
         v-for="item of albums"
         xl="2"
-        cols="12"
+        cols="6"
       >
         <AlbumCard :album="item" />
       </VCol>

--- a/src/views/artists/Artists.vue
+++ b/src/views/artists/Artists.vue
@@ -38,7 +38,7 @@
           <VCol
             v-for="item in props.items"
             :key="item.id"
-            cols="12"
+            cols="6"
             sm="6"
             md="4"
             lg="3"

--- a/src/views/genres/Genres.vue
+++ b/src/views/genres/Genres.vue
@@ -33,7 +33,7 @@
             md="4"
             sm="6"
             xl="2"
-            cols="12"
+            cols="6"
           >
             <GenreCard :genre="item" />
           </VCol>

--- a/src/views/labels/Label.vue
+++ b/src/views/labels/Label.vue
@@ -42,7 +42,7 @@
             md="4"
             sm="6"
             xl="2"
-            cols="12"
+            cols="6"
           >
             <AlbumCard :album="item" :labelForCatNr="label" />
           </VCol>

--- a/src/views/labels/Labels.vue
+++ b/src/views/labels/Labels.vue
@@ -34,7 +34,7 @@
             sm="6"
             v-for="item in props.items"
             xl="2"
-            cols="12"
+            cols="6"
           >
             <LabelCard :label="item" />
           </VCol>


### PR DESCRIPTION
We currently show 1 card per row in all grid views on xs screens. This makes navigating a bit unhandy and requires a lot of scrolling (esp in paginated elements like the home page).
I've changed the grid to show 2 cards per row on all iterators.

This caused the actions in the AlbumCard to warp, so I've removed the margin between the actions on xs screens. (They'll still warp on some very small screens, but this is unavoidable). This was only necessary for the album actions, but I've removed this margin everywhere, for more consistency.

Previous views:
<img width="466" alt="Screenshot 2021-07-17 at 10 26 02" src="https://user-images.githubusercontent.com/48474670/126031178-7e47a711-a637-42d5-a864-9a5312ce0d6b.png">
<img width="471" alt="Screenshot 2021-07-17 at 10 25 53" src="https://user-images.githubusercontent.com/48474670/126031181-84f295f2-efaf-4e9e-a908-0ef362d7cb0c.png">

New views:
<img width="465" alt="Screenshot 2021-07-17 at 10 25 18" src="https://user-images.githubusercontent.com/48474670/126031185-de4c53c5-8770-4868-bc90-c441864739e9.png">
<img width="470" alt="Screenshot 2021-07-17 at 10 24 52" src="https://user-images.githubusercontent.com/48474670/126031186-d9eadb97-d152-4ec4-8016-818bef69d5a2.png">
<img width="471" alt="Screenshot 2021-07-17 at 10 24 42" src="https://user-images.githubusercontent.com/48474670/126031187-aafdb938-1e22-4672-bda4-aa1afa94a66c.png">
