### PR TITLE
Use `setStartLoading` and `removeOld` for empty scopes

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,7 +1,7 @@
 export async function fetchAll(commit, generator, commitAction, scope = null) {
   // If there is no scope present, we prepare for removing old items
   // later (this also influences editability of items)
-  if (scope === null) {
+  if (scope === null || scope.scopes.length === 0) {
     commit("setStartLoading");
   }
   let done = false;
@@ -18,7 +18,7 @@ export async function fetchAll(commit, generator, commitAction, scope = null) {
   }
   commit(commitAction, results);
   // If there is no scope present, we remove old items
-  if (scope === null) {
+  if (scope === null || scope.scopes.length === 0) {
     commit("removeOld");
   }
 }


### PR DESCRIPTION
If a Scope instance is passed without any scopes inside, we should still use `setStartLoading` and `removeOld`, since the result should be the same as the index without a scope.

Fixes #540 

* Tested whether commits are triggered for models without scopes
* Tested whether commits are triggered when no scope is passed to `index`
