### PR TITLE
Don't wrap track actions

### DIFF
--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <span>
+  <span class="text-no-wrap">
     <VTooltip bottom :disabled="track.length !== null">
       <template v-slot:activator="{ on }">
         <span v-on="on">


### PR DESCRIPTION
<!---
  Thanks for contributing to Accentor!  Make sure all GitHub actions
  (lint & build) will pass and fill out the template.

  If any changes to your PR are necessary, we will ask for them
  throughout the review process.
  --->
 
<!---
  Please include a summary of the change and which issue is
  fixed. Please also include relevant motivation and context. If your
  pull request includes visual changes (which will probably be the
  case for anything that isn't a pure logic fix), please include
  screenshots showing those changes. Note that the GitHub ToS requires
  you to have the intellectual property rights required to post
  copyrighted content, which you might not have for cover art included
  in your screenshot depending on your jurisdiction and the license
  of the cover art: https://docs.github.com/en/github/site-policy/github-terms-of-service#d-user-generated-content
  --->
Due to #532 limiting the width of the last column, the content of those cells would wrap unnecessarily. This makes sure that column doesn't wrap. I still don't really get why I didn't see this when making that PR (you can see in the screenshots there that it wasn't a problem), but :woman_shrugging:.


Before:
![screenshot_2021-07-20-140143](https://user-images.githubusercontent.com/42220376/126320352-e0888893-5d21-4a16-9f06-9527d38c5813.png)

After:
![screenshot_2021-07-20-140047](https://user-images.githubusercontent.com/42220376/126320291-5171ac79-7e8f-4857-90da-7991f497065e.png)

Fixes #541.

<!---
  If you did any manual testing (please do so), describe here what you
  tested and how. Provide instructions so that your tests can be
  easily run again by a maintainer.
  --->
