### PR TITLE
Improve spacing between actions

### DIFF
--- a/src/Main.vue
+++ b/src/Main.vue
@@ -33,7 +33,7 @@ a {
 }
 
 @media (min-width: map-get($grid-breakpoints, "sm")) {
-  .sm\:actions--wide {
+  .actions--sm-wide {
     .actions__button {
       margin: 8px 16px 8px 0;
     }

--- a/src/Main.vue
+++ b/src/Main.vue
@@ -15,7 +15,28 @@ export default {
 </script>
 
 <style lang="scss">
+@import "~vuetify/src/styles/styles.sass";
+
 a {
   text-decoration: none;
+}
+
+.actions {
+  .actions__button {
+    margin: 4px 8px 4px 0;
+  }
+}
+.actions--wide {
+  .actions__button {
+    margin: 8px 16px 8px 0;
+  }
+}
+
+@media (min-width: map-get($grid-breakpoints, "sm")) {
+  .sm\:actions--wide {
+    .actions__button {
+      margin: 8px 16px 8px 0;
+    }
+  }
 }
 </style>

--- a/src/components/AlbumActions.vue
+++ b/src/components/AlbumActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <span>
+  <span class="actions">
     <VTooltip bottom :disabled="playableTracks.length !== 0">
       <template v-slot:activator="{ on }">
         <span v-on="on">
@@ -7,7 +7,7 @@
             @click.stop.prevent="startTracks"
             :disabled="playableTracks.length === 0"
             color="primary"
-            class="ml-0 ma-1 ma-sm-2"
+            class="actions__button"
             text
             icon
             small
@@ -25,7 +25,7 @@
             @click.stop.prevent="addTracks"
             :disabled="playableTracks.length === 0"
             color="success"
-            class="ma-1 ma-sm-2"
+            class="actions__button"
             text
             icon
             small
@@ -49,7 +49,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ma-1 ma-sm-2"
+            class="actions__button"
             text
             icon
             small
@@ -67,7 +67,7 @@
             @click.stop.prevent="deleteAlbum"
             :disabled="album.loaded < startLoading"
             color="danger"
-            class="mr-0 ma-1 ma-sm-2"
+            class="mr-0 actions__button"
             text
             href="#"
             icon

--- a/src/components/AlbumCard.vue
+++ b/src/components/AlbumCard.vue
@@ -34,7 +34,7 @@
       </div>
     </VCardText>
     <VCardActions>
-      <AlbumActions :album="album" class="sm:actions--wide" />
+      <AlbumActions :album="album" class="actions--sm-wide" />
     </VCardActions>
   </VCard>
 </template>

--- a/src/components/AlbumCard.vue
+++ b/src/components/AlbumCard.vue
@@ -34,7 +34,7 @@
       </div>
     </VCardText>
     <VCardActions>
-      <AlbumActions :album="album" />
+      <AlbumActions :album="album" class="sm:actions--wide" />
     </VCardActions>
   </VCard>
 </template>

--- a/src/components/ArtistActions.vue
+++ b/src/components/ArtistActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <span>
+  <span class="actions">
     <EditReviewComment :item="artist" :update="flag" />
     <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
       <template v-slot:activator="{ on }">
@@ -12,7 +12,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ml-0 ma-1 ma-sm-2"
+            class="actions__button"
             text
             icon
             small
@@ -38,7 +38,7 @@
             @click.stop.prevent="deleteArtist"
             :disabled="waitingForReload"
             color="danger"
-            class="mr-0 ma-1 ma-sm-2"
+            class="actions__button mr-0"
             href="#"
             text
             icon

--- a/src/components/ArtistCard.vue
+++ b/src/components/ArtistCard.vue
@@ -22,7 +22,7 @@
       {{ artist.name }}
     </VCardTitle>
     <VCardActions>
-      <ArtistActions :artist="artist" class="sm:actions--wide" />
+      <ArtistActions :artist="artist" class="actions--sm-wide" />
     </VCardActions>
   </VCard>
 </template>

--- a/src/components/ArtistCard.vue
+++ b/src/components/ArtistCard.vue
@@ -22,7 +22,7 @@
       {{ artist.name }}
     </VCardTitle>
     <VCardActions>
-      <ArtistActions :artist="artist" />
+      <ArtistActions :artist="artist" class="sm:actions--wide" />
     </VCardActions>
   </VCard>
 </template>

--- a/src/components/ArtistMergeDialog.vue
+++ b/src/components/ArtistMergeDialog.vue
@@ -10,7 +10,7 @@
         v-on="on"
         :disabled="disabled"
         @click.stop.prevent
-        class="ma-1 ma-sm-2"
+        class="actions__button"
         color="edit"
         text
         icon

--- a/src/components/EditReviewComment.vue
+++ b/src/components/EditReviewComment.vue
@@ -1,7 +1,7 @@
 <template>
   <VBtn
     color="flag"
-    class="ma-1 ma-sm-2"
+    class="actions__button"
     text
     icon
     small

--- a/src/components/GenreActions.vue
+++ b/src/components/GenreActions.vue
@@ -11,7 +11,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ml-0 ma-1 ma-sm-2"
+            class="actions__button"
             text
             icon
             small
@@ -37,7 +37,7 @@
             @click.stop.prevent="deleteGenre"
             :disabled="waitingForReload"
             color="danger"
-            class="mr-0 ma-1 ma-sm-2"
+            class="actions__button mr-0"
             href="#"
             text
             icon

--- a/src/components/GenreCard.vue
+++ b/src/components/GenreCard.vue
@@ -4,7 +4,7 @@
       {{ genre.name }}
     </VCardTitle>
     <VCardActions>
-      <GenreActions :genre="genre" class="sm:actions--wide" />
+      <GenreActions :genre="genre" class="actions--sm-wide" />
     </VCardActions>
   </VCard>
 </template>

--- a/src/components/GenreCard.vue
+++ b/src/components/GenreCard.vue
@@ -4,7 +4,7 @@
       {{ genre.name }}
     </VCardTitle>
     <VCardActions>
-      <GenreActions :genre="genre" />
+      <GenreActions :genre="genre" class="sm:actions--wide" />
     </VCardActions>
   </VCard>
 </template>

--- a/src/components/GenreMergeDialog.vue
+++ b/src/components/GenreMergeDialog.vue
@@ -10,7 +10,7 @@
         v-on="on"
         :disabled="disabled"
         @click.stop.prevent
-        class="ma-1 ma-sm-2"
+        class="actions__button"
         color="edit"
         text
         icon

--- a/src/components/LabelActions.vue
+++ b/src/components/LabelActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-if="isModerator">
+  <span v-if="isModerator" class="actions">
     <VTooltip bottom :disabled="!waitingForReload">
       <template v-slot:activator="{ on }">
         <span v-on="on">
@@ -11,7 +11,7 @@
             }"
             :disabled="waitingForReload"
             color="edit"
-            class="ml-0 ma-1 ma-sm-2"
+            class="actions__button"
             text
             icon
             small
@@ -37,7 +37,7 @@
             @click.stop.prevent="deleteLabel"
             :disabled="waitingForReload"
             color="danger"
-            class="mr-0 ma-1 ma-sm-2"
+            class="mr-0 actions__button"
             href="#"
             text
             icon

--- a/src/components/LabelCard.vue
+++ b/src/components/LabelCard.vue
@@ -4,7 +4,7 @@
       {{ label.name }}
     </VCardTitle>
     <VCardActions>
-      <LabelActions :label="label" class="sm:actions--wide" />
+      <LabelActions :label="label" class="actions--sm-wide" />
     </VCardActions>
   </VCard>
 </template>

--- a/src/components/LabelCard.vue
+++ b/src/components/LabelCard.vue
@@ -4,7 +4,7 @@
       {{ label.name }}
     </VCardTitle>
     <VCardActions>
-      <LabelActions :label="label" />
+      <LabelActions :label="label" class="sm:actions--wide" />
     </VCardActions>
   </VCard>
 </template>

--- a/src/components/LabelMergeDialog.vue
+++ b/src/components/LabelMergeDialog.vue
@@ -10,7 +10,7 @@
         v-on="on"
         :disabled="disabled"
         @click.stop.prevent
-        class="ma-1 ma-sm-2"
+        class="actions__button"
         color="edit"
         text
         icon

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="text-no-wrap">
+  <span class="text-no-wrap actions">
     <VTooltip bottom :disabled="track.length !== null">
       <template v-slot:activator="{ on }">
         <span v-on="on">
@@ -7,7 +7,7 @@
             @click="startTrack"
             :disabled="track.length === null"
             color="primary"
-            class="ma-1"
+            class="actions__button"
             text
             icon
             small
@@ -25,7 +25,7 @@
             @click="addTrack"
             :disabled="track.length === null"
             color="success"
-            class="ma-1"
+            class="actions__button"
             text
             icon
             small
@@ -39,7 +39,7 @@
     <EditReviewComment :item="track" :update="flag" />
     <VMenu v-if="isModerator">
       <template v-slot:activator="{ on, attrs }">
-        <VBtn class="ma-1" small icon v-bind="attrs" v-on="on">
+        <VBtn class="actions__button mr-0" small icon v-bind="attrs" v-on="on">
           <VIcon>mdi-dots-vertical</VIcon>
         </VBtn>
       </template>

--- a/src/views/albums/Album.vue
+++ b/src/views/albums/Album.vue
@@ -47,7 +47,7 @@
             {{ al.catalogue_number || $t("music.label.catalogue-number-none") }}
           </div>
           <div>
-            <AlbumActions :album="album" />
+            <AlbumActions :album="album" class="actions--wide" />
           </div>
         </div>
       </VCol>

--- a/src/views/artists/Artist.vue
+++ b/src/views/artists/Artist.vue
@@ -24,7 +24,7 @@
           <h2 class="text-h4">{{ artist.name }}</h2>
         </div>
         <div>
-          <ArtistActions :artist="artist" />
+          <ArtistActions :artist="artist" class="actions" />
         </div>
       </VCol>
     </VRow>

--- a/src/views/genres/Genre.vue
+++ b/src/views/genres/Genre.vue
@@ -6,7 +6,7 @@
           <h2 class="text-h4">{{ genre.name }}</h2>
         </div>
         <div>
-          <GenreActions :genre="genre" />
+          <GenreActions :genre="genre" class="actions--wide" />
         </div>
       </VCol>
     </VRow>

--- a/src/views/labels/Label.vue
+++ b/src/views/labels/Label.vue
@@ -18,7 +18,7 @@
               <h2 class="text-h4">{{ label.name }}</h2>
             </div>
             <div>
-              <LabelActions :label="label" />
+              <LabelActions :label="label" class="actions--wide" />
             </div>
           </VCol>
           <VCol cols="12" sm="8" md="6" lg="4" xl="2">


### PR DESCRIPTION
Re #544 #541 
I've reworked the system for actions spacing, so we can modify the space between all icons from the parent component.
this way the `EditReviewComment` icon can have different spacing depending on the context it is in.
I've still added a `mr-0` utility class to the last icon (for moderator and admins), this is mostly too prevent the icons from wrapping sooner than necessary.

This doesn't result in much visual difference from before. The biggest place to notice a difference is the Flag icon in the `TrackActions`, which now has the same spacing as the other elements.

### Before:
<img width="1201" alt="Screenshot 2021-07-21 at 14 07 56" src="https://user-images.githubusercontent.com/48474670/126486907-b5d66d88-cbba-4d3e-8676-16a238f6b728.png">
<img width="1204" alt="Screenshot 2021-07-21 at 14 08 06" src="https://user-images.githubusercontent.com/48474670/126486910-0d029669-c2cd-44c7-ae0d-efc3121ebd82.png">
<img width="436" alt="Screenshot 2021-07-21 at 14 08 34" src="https://user-images.githubusercontent.com/48474670/126486913-c211fc81-fe2c-47d2-876b-dfb93674b010.png">
<img width="457" alt="Screenshot 2021-07-21 at 14 08 53" src="https://user-images.githubusercontent.com/48474670/126486915-14943224-adfe-40a7-b638-1d8d07ccb784.png">

### After:
<img width="1138" alt="Screenshot 2021-07-21 at 14 11 03" src="https://user-images.githubusercontent.com/48474670/126486956-761c367b-2bc5-46f1-a0c0-3bada62242c7.png">
<img width="1137" alt="Screenshot 2021-07-21 at 14 10 52" src="https://user-images.githubusercontent.com/48474670/126486958-be6aac59-e354-47dd-a760-b7507310b37c.png">
<img width="461" alt="Screenshot 2021-07-21 at 14 10 35" src="https://user-images.githubusercontent.com/48474670/126486960-eb659a5b-f9c1-4a91-b019-4c3c0b64b40b.png">
<img width="458" alt="Screenshot 2021-07-21 at 14 10 15" src="https://user-images.githubusercontent.com/48474670/126486961-9dc4e9f7-ee65-4326-b921-0164d23b25e9.png">
