### PR TITLE
Run CI actions on pull request and pushes to tags or main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
As we recently saw in https://github.com/accentor/api/pull/229, our CI actions are not run on external pull requests. This should fix that. To avoid each action running twice for internal pull requests, I've restricted running the actions on push to only pushes to tags and the main branch.