### PR TITLE
Fix double navigation on startup

### DIFF
--- a/src/mixins/Paginated.js
+++ b/src/mixins/Paginated.js
@@ -17,7 +17,10 @@ export default {
   },
   watch: {
     "pagination.page": function () {
-      if (this.savePagination === undefined || this.savePagination) {
+      if (
+        (this.savePagination === undefined || this.savePagination) &&
+        parseInt(this.$route.query.page) !== this.pagination.page
+      ) {
         this.$router.replace({
           query: {
             ...this.$route.query,

--- a/src/mixins/Searchable.js
+++ b/src/mixins/Searchable.js
@@ -17,7 +17,7 @@ export default {
   },
   watch: {
     search: function () {
-      if (this.saveSearch) {
+      if (this.saveSearch && this.$route.query.search !== this.search) {
         this.$router.replace({
           query: {
             ...this.$route.query,


### PR DESCRIPTION
The VueRouter currently prints errors like:
```
Uncaught (in promise) NavigationDuplicated: Avoided redundant navigation to current location: "/app/artists?page=1&search=swans".
```
This mostly happens when directly loading a url with a search query or a page number (other than 1).

To avoid these errors, I've added a check that we should not try to navigate if the query in the url matches what we want to navigate to.