### PR TITLE
Reset scroll position on navigate

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -186,6 +186,13 @@ const router = new Router({
     },
     { path: "*", redirect: "/app/" },
   ],
+  scrollBehavior(to, from, savedPosition) {
+    if (to.path === from.path) {
+      return savedPosition;
+    } else {
+      return { x: 0, y: 0 };
+    }
+  },
 });
 
 store.watch(


### PR DESCRIPTION
Fixes #549 

I've chosen to reset the scroll position when we navigate to a different path. This means that the scroll will not reset if when using the pagination or searching
