### PR TITLE
Avoid fetching audio for `null` track after last track

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -189,6 +189,10 @@ export default {
   },
   watch: {
     async currentTrackURL() {
+      if (this.currentTrackURL === null) {
+        return;
+      }
+
       this.$refs.audio.src = this.currentTrackURL;
       if (this.playing) {
         try {


### PR DESCRIPTION
After the last track is finished, we try and fetch `${baseURL}/app/null` or similar. 
To avoid this unnecessary network request, I've placed guard clause before the audioElement's src is set
