### PR TITLE
Set default language in store

### DIFF
--- a/src/store/user_settings.js
+++ b/src/store/user_settings.js
@@ -1,7 +1,7 @@
 export default {
   namespaced: true,
   state: {
-    locale: null,
+    locale: "en",
     codecConversionID: null,
   },
   mutations: {


### PR DESCRIPTION
Since the application uses English by the default, we should also set this as the default in the store.

This fixes a bug where a user is able to set the locale to `""` (the default of `newLocale` in `views/settings/Settings.vue`), resulting in a broken interface (which just shows the keys). If we set the default to what it actually is, the user will not be able to set it to anything but the available options.