### PR TITLE
Fix spacing issue in VDataFooter

### DIFF
--- a/src/Main.vue
+++ b/src/Main.vue
@@ -46,4 +46,9 @@ a {
 .white-space-nowrap {
   white-space: nowrap;
 }
+
+// Temporary fix until https://github.com/vuetifyjs/vuetify/issues/13678 is resolved
+.v-data-footer {
+  justify-content: flex-end;
+}
 </style>


### PR DESCRIPTION
A small fix to correctly align the pagination in all VDataFooter's. This wouldn't work if we added extra features to the VDataFooter, but I don't see that happening soon.

If/when this is fixed in vuetify itself, we can simply revert this commit.

## Views with fix
<img width="910" alt="Screenshot 2021-08-14 at 10 21 56" src="https://user-images.githubusercontent.com/48474670/129439888-b14f1efb-405a-466b-bc2a-b3cb6ff1053b.png">
<img width="905" alt="Screenshot 2021-08-14 at 10 23 12" src="https://user-images.githubusercontent.com/48474670/129439922-7de08714-7dea-4e9a-a486-f8b95574f9a6.png">