### PR TITLE
Only update `seekTime` from `audio.currentTime` when playing

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -321,7 +321,7 @@ export default {
     ]),
     checkTime() {
       const time = Math.floor(this.$refs.audio.currentTime);
-      if (time !== this.seekTime) {
+      if (this.currentTrack && time !== this.seekTime) {
         this.setSeekTime(time);
       }
     },


### PR DESCRIPTION
Fixes #589 

When logging the players's `seekTime` & audio element's `currentTime` I noticed that `checkTime` is still called after the track has already finished. This caused `seekTime` to be the set to the audio's `currentTime` after the store's `player/nextTrack` was called and thus returning the wrong seekTime (for our purposes).