### PR TITLE
Fix sort tracks by play count

### DIFF
--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -168,6 +168,7 @@ export default {
         value: "play_count",
         align: "end",
         width: "1px",
+        class: "text-no-wrap",
       },
       {
         text: this.$t("common.actions"),

--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -242,7 +242,8 @@ export default {
           break;
         case "play_count":
           sortFunction = (t1, t2) =>
-            (this.playCountsByTrack[t1] = this.playCountsByTrack[t2]);
+            (this.playCountsByTrack[t1.id] || 0) -
+            (this.playCountsByTrack[t2.id] || 0);
           break;
         case "title":
           sortFunction = (t1, t2) =>


### PR DESCRIPTION
Fixes two problems:
* The text in the table wrapped, making the sort icon appear underneath or above "played"
* The sort function that compared by play_count contained some basic mistakes
