### PR TITLE
Add hidden to track artists

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'"
   },
   "dependencies": {
-    "@accentor/api-client-js": "^0.15.0",
+    "@accentor/api-client-js": "^0.16.0",
     "@mdi/font": "^6.5.95",
     "@mdi/svg": "^6.5.95",
     "fetch-retry": "^5.0.1",

--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -416,6 +416,7 @@ export default {
                   artist_id: id,
                   name: ta.name || ta.artist_id,
                   role: ta.role,
+                  hidden: ta.hidden,
                   order: index + 1,
                 });
               } else {
@@ -426,6 +427,7 @@ export default {
                 artist_id: ta.artist_id.id,
                 name: ta.name || ta.artist_id.name,
                 role: ta.role,
+                hidden: ta.hidden,
                 order: index + 1,
               });
             }
@@ -528,6 +530,7 @@ export default {
         artist_id: null,
         name: "",
         role: "main",
+        hidden: false,
       });
     },
     resetState() {

--- a/src/components/TrackArtists.vue
+++ b/src/components/TrackArtists.vue
@@ -3,7 +3,12 @@
     <VMenu open-on-hover offset-y>
       <template v-slot:activator="{ on }">
         <div v-on="on">
-          {{ track_artists.filter((a) => !a.hidden).map((a) => a.name).join(" / ") }}
+          {{
+            track_artists
+              .filter((a) => !a.hidden)
+              .map((a) => a.name)
+              .join(" / ")
+          }}
         </div>
       </template>
       <VList dense>

--- a/src/components/TrackArtists.vue
+++ b/src/components/TrackArtists.vue
@@ -3,7 +3,7 @@
     <VMenu open-on-hover offset-y>
       <template v-slot:activator="{ on }">
         <div v-on="on">
-          {{ track_artists.map((a) => a.name).join(" / ") }}
+          {{ track_artists.filter((a) => !a.hidden).map((a) => a.name).join(" / ") }}
         </div>
       </template>
       <VList dense>

--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -65,19 +65,19 @@
         <VTextField :label="$t('common.name')" v-model="item.name" />
         <VRow>
           <VCol>
-          <VAutocomplete
-            :items="roles"
-            :label="$t('music.artist.role')"
-            v-model="item.role"
-            class="flex-grow-2"
-          />
+            <VAutocomplete
+              :items="roles"
+              :label="$t('music.artist.role')"
+              v-model="item.role"
+              class="flex-grow-2"
+            />
           </VCol>
           <VCol class="flex-grow-0 flex-shrink-0">
-          <VCheckbox
-            v-model="item.hidden"
-            label="Hide in overview?"
-            color="red"
-            class="white-space-nowrap"
+            <VCheckbox
+              v-model="item.hidden"
+              label="Hide in overview?"
+              color="red"
+              class="white-space-nowrap"
             ></VCheckbox>
           </VCol>
         </VRow>

--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -63,11 +63,24 @@
           v-model="item.artist_id"
         />
         <VTextField :label="$t('common.name')" v-model="item.name" />
-        <VAutocomplete
-          :items="roles"
-          :label="$t('music.artist.role')"
-          v-model="item.role"
-        />
+        <VRow>
+          <VCol>
+          <VAutocomplete
+            :items="roles"
+            :label="$t('music.artist.role')"
+            v-model="item.role"
+            class="flex-grow-2"
+          />
+          </VCol>
+          <VCol class="flex-grow-0 flex-shrink-0">
+          <VCheckbox
+            v-model="item.hidden"
+            label="Hide in overview?"
+            color="red"
+            class="white-space-nowrap"
+            ></VCheckbox>
+          </VCol>
+        </VRow>
         <VDivider light v-if="index !== trackArtists.length - 1" />
       </VCol>
     </VRow>

--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -75,10 +75,21 @@
           <VCol class="flex-grow-0 flex-shrink-0">
             <VCheckbox
               v-model="item.hidden"
-              label="Hide in overview?"
               color="red"
               class="white-space-nowrap"
-            ></VCheckbox>
+            >
+              <template v-slot:label>
+                {{ $t("music.artist.hide.label") }}
+                <VTooltip bottom>
+                  <template v-slot:activator="{ on, attrs }">
+                    <VIcon class="ml-2" small="true" v-bind="attrs" v-on="on">
+                      mdi-information
+                    </VIcon>
+                  </template>
+                  <span>{{ $t("music.artist.hide.explanation") }}</span>
+                </VTooltip>
+              </template>
+            </VCheckbox>
           </VCol>
         </VRow>
         <VDivider light v-if="index !== trackArtists.length - 1" />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -259,6 +259,10 @@
 		"artist": {
 			"add": "Add artist",
 			"artist-s": "Artist(s)",
+			"hide": {
+				"label": "Hide in overview?",
+				"explanation": "If an artist is hidden, they will only be shown in detailed lists."
+			},
 			"merge": "Merge artists",
 			"merge-into": "Merge {obj} into",
 			"new": "New artist",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -255,6 +255,10 @@
 		"artist": {
 			"add": "Voeg artiest toe",
 			"artist-s": "Artiest(en)",
+			"hide": {
+				"label": "Verberg in overzicht?",
+				"explanation": "Als een artiest verborgen is, wordt deze alleen getoonde in de detailweergaves."
+			},
 			"merge": "Artiesten samenvoegen",
 			"merge-into": "Voeg {obj} samen met",
 			"new": "Nieuwe artiest",

--- a/src/views/tracks/EditTrack.vue
+++ b/src/views/tracks/EditTrack.vue
@@ -205,6 +205,7 @@ export default {
             name: ta.name,
             role: ta.role,
             order: ta.order,
+            hidden: ta.hidden,
           };
         })
         .sort((a1, a2) => a1.order - a2.order);
@@ -217,6 +218,7 @@ export default {
         artist_id: null,
         name: "",
         role: "main",
+        hidden: false,
       });
     },
     async submit() {
@@ -256,6 +258,7 @@ export default {
                 artist_id: id,
                 name: ta.name || ta.artist_id,
                 role: ta.role,
+                hidden: ta.hidden ? 1 : 0,
                 order: index + 1,
               });
             } else {
@@ -266,6 +269,7 @@ export default {
               artist_id: ta.artist_id.id,
               name: ta.name || ta.artist_id.name,
               role: ta.role,
+              hidden: ta.hidden ? 1 : 0,
               order: index + 1,
             });
           }


### PR DESCRIPTION
Matches accentor/api#273

* Hides the TrackArtist in the TrackTable if hidden
* Allows editing of this status.

The fields per track artist now look like this:
<img width="636" alt="Screenshot 2021-11-27 at 15 45 14" src="https://user-images.githubusercontent.com/48474670/143686810-1c5d5eac-18af-4456-ad4d-bd248fecff45.png">


