### PR TITLE
Save TrackTable sort in url

### DIFF
--- a/src/components/TracksTable.vue
+++ b/src/components/TracksTable.vue
@@ -25,6 +25,8 @@
       :items="filteredItems"
       :items-per-page="30"
       :page.sync="pagination.page"
+      :sort-by.sync="sortable.sortBy"
+      :sort-desc.sync="sortable.sortDesc"
       :show-select="isModerator"
       :single-select="singleSelect"
       :custom-sort="sortFunction"
@@ -106,6 +108,7 @@ import TrackActions from "./TrackActions";
 import Paginated from "../mixins/Paginated";
 import { mapGetters, mapState } from "vuex";
 import Searchable from "../mixins/Searchable";
+import Sortable from "../mixins/Sortable";
 import TrackArtists from "./TrackArtists";
 import TrackGenres from "./TrackGenres";
 import MassEditDialog from "./MassEditDialog";
@@ -119,7 +122,7 @@ import {
 export default {
   name: "TracksTable",
   components: { TrackGenres, TrackActions, TrackArtists, MassEditDialog },
-  mixins: [Paginated, Searchable],
+  mixins: [Paginated, Searchable, Sortable],
   props: {
     tracks: { default: () => [], type: Array },
     savePagination: { default: true, type: Boolean },

--- a/src/mixins/Sortable.js
+++ b/src/mixins/Sortable.js
@@ -1,0 +1,54 @@
+export default {
+  data() {
+    return {
+      sortable: { sortBy: null, sortDesc: null },
+    };
+  },
+  props: {
+    saveSort: { default: true, type: Boolean },
+  },
+  watch: {
+    "sortable.sortBy": function () {
+      if (
+        (this.saveSort === undefined || this.saveSort) &&
+        this.$route.query.sortBy !== this.sortable.sortBy
+      ) {
+        this.$router.replace({
+          query: {
+            ...this.$route.query,
+            sortBy: this.sortable.sortBy,
+          },
+        });
+      }
+    },
+    "sortable.sortDesc": function () {
+      if (
+        (this.saveSort === undefined || this.saveSort) &&
+        this.$route.query.sortDesc !== this.sortable.sortDesc?.toString()
+      ) {
+        this.$router.replace({
+          query: {
+            ...this.$route.query,
+            sortDesc: this.sortable.sortDesc,
+          },
+        });
+      }
+    },
+    "$route.query.sortBy": {
+      handler() {
+        if (this.saveSort === undefined || this.saveSort) {
+          this.sortable.sortBy = this.$route.query.sortBy || null;
+        }
+      },
+      immediate: true,
+    },
+    "$route.query.sortDesc": {
+      handler() {
+        if (this.saveSort === undefined || this.saveSort) {
+          this.sortable.sortDesc = this.$route.query.sortDesc === "true";
+        }
+      },
+      immediate: true,
+    },
+  },
+};


### PR DESCRIPTION
Save sortBy and sortDesc of TrackTable in the url, in the same way that we do for pagination and search.

(Note that Vuetify also allows sorting by multiple properties, for which this code will probably not work. As we don't use this, I've ignored this.)