### PR TITLE
Fix prop type of VIcon

### DIFF
--- a/src/components/TrackFormArtists.vue
+++ b/src/components/TrackFormArtists.vue
@@ -82,7 +82,7 @@
                 {{ $t("music.artist.hide.label") }}
                 <VTooltip bottom>
                   <template v-slot:activator="{ on, attrs }">
-                    <VIcon class="ml-2" small="true" v-bind="attrs" v-on="on">
+                    <VIcon class="ml-2" :small="true" v-bind="attrs" v-on="on">
                       mdi-information
                     </VIcon>
                   </template>


### PR DESCRIPTION
Vuetify was throwing a lot of console errors, since we were passing a string instead of a boolean to `VIcon`