### PR TITLE
Improve top tracks

### DIFF
--- a/src/components/TopTracksList.vue
+++ b/src/components/TopTracksList.vue
@@ -8,7 +8,12 @@
             {{ index + 1 }}.
           </span>
           <span class="top-item__name">
-            {{ item.trackArtists.filter((a) => !a.hidden).map((a) => a.name).join(" / ") }}
+            {{
+              item.trackArtists
+                .filter((a) => !a.hidden)
+                .map((a) => a.name)
+                .join(" / ")
+            }}
             - {{ item.title }}
           </span>
         </span>

--- a/src/components/TopTracksList.vue
+++ b/src/components/TopTracksList.vue
@@ -120,8 +120,13 @@ export default {
   }
 
   &__text {
-    overflow: hidden;
-    white-space: nowrap;
+    display: flex;
+    line-height: 1.2;
+    margin-bottom: 0.125rem;
+  }
+
+  &__position {
+    margin-right: 0.25rem;
   }
 
   &__count {

--- a/src/components/TopTracksList.vue
+++ b/src/components/TopTracksList.vue
@@ -8,7 +8,7 @@
             {{ index + 1 }}.
           </span>
           <span class="top-item__name">
-            {{ item.trackArtists.map((a) => a.name).join(" / ") }}
+            {{ item.trackArtists.filter((a) => !a.hidden).map((a) => a.name).join(" / ") }}
             - {{ item.title }}
           </span>
         </span>


### PR DESCRIPTION
re #659 

Two small improvements to top tracks:
* hidden artists aren't shown anymore
* The artists/title now wrap instead of overflowing. 
  This won't be ideal for very long titles or many track artists. So maybe we should also use line-clamp to limit this to x number of lines? Or use `word-break` so we reduce the whitespace?

We might also want to put the track title before the artists? I'm not sure about it.


<img width="652" alt="Screenshot 2021-12-11 at 12 51 10" src="https://user-images.githubusercontent.com/48474670/145675505-c71fa775-1680-4e8d-b402-0dc00285f2b1.png">

