### PR TITLE
Fix img on new album/new artist form

### DIFF
--- a/src/components/AlbumForm.vue
+++ b/src/components/AlbumForm.vue
@@ -110,7 +110,7 @@
         />
         <ImagePicker
           v-model="newAlbum.image"
-          :currentImg="album.image250"
+          :currentImg="album && album.image250"
           :placeholder="require('@mdi/svg/svg/album.svg')"
         />
         <h4 class="text-subtitle-1">{{ $tc("music.artists", 2) }}</h4>

--- a/src/components/ArtistForm.vue
+++ b/src/components/ArtistForm.vue
@@ -18,7 +18,7 @@
         />
         <ImagePicker
           v-model="newArtist.image"
-          :currentImg="artist.image250"
+          :currentImg="artist && artist.image250"
           :placeholder="require('@mdi/svg/svg/account-music.svg')"
         />
         <VCheckbox

--- a/src/components/ImagePicker.vue
+++ b/src/components/ImagePicker.vue
@@ -85,7 +85,9 @@ export default {
   },
   computed: {
     previewSrc() {
-      return `data:${this.value.mimetype};base64, ${this.value.data}`;
+      return (
+        this.value && `data:${this.value.mimetype};base64, ${this.value.data}`
+      );
     },
     hasImage() {
       return (


### PR DESCRIPTION
Fixes an issue where the form for new albums or new artists would not render because we try to access `album.image250` while album is null.

Also fixes a small issue wehere the `ImagePicker`'s `previewSrc` would generate an issue, because we wanted to access a property on `null`