### PR TITLE
Add play counts to stats

### DIFF
--- a/src/components/PlayCountCard.vue
+++ b/src/components/PlayCountCard.vue
@@ -1,0 +1,70 @@
+<template>
+  <VCard class="px-2 py-4">
+    <div class="text-center mb-4">
+      <span class="text-subtitle d-block">
+        {{ $t("stats.count.playCount.before") }}
+      </span>
+      <span class="text-h5 d-block">{{ Math.floor(animatedCount) }}</span>
+      <span class="text-subtitle d-block">
+        {{ $t("stats.count.playCount.after") }}
+      </span>
+    </div>
+    <div class="text-center">
+      <span class="text-subtitle d-block">
+        {{ $t("stats.count.playTime.before") }}
+      </span>
+      <span class="text-h5 d-block">
+        {{ Math.floor(animatedTime) | length }}
+      </span>
+      <span class="text-subtitle d-block">
+        {{ $t("stats.count.playTime.after") }}
+      </span>
+    </div>
+  </VCard>
+</template>
+
+<script>
+import { mapState } from "vuex";
+import { gsap } from "gsap";
+
+export default {
+  name: "PlayCountCard",
+  props: {
+    plays: {
+      type: Array,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      animatedCount: 0,
+      animatedTime: 0,
+    };
+  },
+  computed: {
+    ...mapState("tracks", ["tracks"]),
+    playCount() {
+      return this.plays.length;
+    },
+    playTime() {
+      return this.plays.reduce((acc, cur) => {
+        return acc + (this.tracks[cur.track_id]?.length || 0);
+      }, 0);
+    },
+  },
+  watch: {
+    playCount(newValue) {
+      gsap.to(this.$data, { duration: 1.2, animatedCount: newValue });
+    },
+    playTime(newValue) {
+      gsap.to(this.$data, { duration: 1.4, animatedTime: newValue });
+    },
+  },
+};
+</script>
+
+<style></style>

--- a/src/components/PlayCountCard.vue
+++ b/src/components/PlayCountCard.vue
@@ -1,24 +1,71 @@
 <template>
   <VCard class="px-2 py-4">
-    <div class="text-center mb-4">
-      <span class="text-subtitle d-block">
-        {{ $t("stats.count.playCount.before") }}
+    <div
+      class="
+        text-center
+        mb-4
+        text-h6
+        font-weight-regular
+        grey--text
+        text--darken-3
+      "
+    >
+      {{ $t("stats.count.playCount.before") }}
+      <span
+        class="text-h4 d-block"
+        :class="animatedCount ? 'primary--text' : 'grey--text text--darken-1'"
+      >
+        {{ Math.floor(animatedCount) }}
       </span>
-      <span class="text-h5 d-block">{{ Math.floor(animatedCount) }}</span>
-      <span class="text-subtitle d-block">
-        {{ $t("stats.count.playCount.after") }}
-      </span>
+      {{ $t("stats.count.playCount.after") }}
     </div>
-    <div class="text-center">
-      <span class="text-subtitle d-block">
-        {{ $t("stats.count.playTime.before") }}
-      </span>
-      <span class="text-h5 d-block">
-        {{ Math.floor(animatedTime) | length }}
-      </span>
-      <span class="text-subtitle d-block">
-        {{ $t("stats.count.playTime.after") }}
-      </span>
+    <div class="text-center text-h6 font-weight-regular">
+      {{ $t("stats.count.playTime.before") }}
+      <div class="play-time grey--text text--darken-3">
+        <span
+          class="text-h4 d-block text-right text--darken-1"
+          :class="animatedTime.days ? 'primary--text' : 'grey--text'"
+        >
+          {{ Math.floor(animatedTime.days) }}
+        </span>
+        <span class="text-subtitle-1 text-left">
+          {{ $tc("stats.count.playTime.days", Math.floor(animatedTime.days)) }}
+        </span>
+        <span
+          class="text-h4 d-block text-right text--darken-1"
+          :class="
+            animatedTime.days + animatedTime.hours
+              ? 'primary--text'
+              : 'grey--text'
+          "
+        >
+          {{ Math.floor(animatedTime.hours) }}
+        </span>
+        <span class="text-subtitle-1 text-left">
+          {{
+            $tc("stats.count.playTime.hours", Math.floor(animatedTime.hours))
+          }}
+        </span>
+        <span
+          class="text-h4 d-block text-right text--darken-1"
+          :class="
+            animatedTime.days + animatedTime.hours + animatedTime.minutes
+              ? 'primary--text'
+              : 'grey--text'
+          "
+        >
+          {{ Math.floor(animatedTime.minutes) }}
+        </span>
+        <span class="text-subtitle-1 text-left">
+          {{
+            $tc(
+              "stats.count.playTime.minutes",
+              Math.floor(animatedTime.minutes)
+            )
+          }}
+        </span>
+      </div>
+      {{ $t("stats.count.playTime.after") }}
     </div>
   </VCard>
 </template>
@@ -42,7 +89,11 @@ export default {
   data() {
     return {
       animatedCount: 0,
-      animatedTime: 0,
+      animatedTime: {
+        days: 0,
+        hours: 0,
+        minutes: 0,
+      },
     };
   },
   computed: {
@@ -60,11 +111,35 @@ export default {
     playCount(newValue) {
       gsap.to(this.$data, { duration: 1.2, animatedCount: newValue });
     },
-    playTime(newValue) {
-      gsap.to(this.$data, { duration: 1.4, animatedTime: newValue });
+    async playTime(newValue) {
+      const newDays = Math.floor(newValue / 86400);
+      const newHours = Math.floor((newValue % 86400) / 3600);
+      const newMinutes = Math.floor(((newValue % 86400) % 3600) / 60);
+      if (newDays) {
+        await gsap.to(this.$data.animatedTime, {
+          duration: 0.4,
+          days: newDays,
+        });
+      }
+      await gsap.to(this.$data.animatedTime, {
+        duration: 0.5,
+        hours: newHours,
+      });
+      await gsap.to(this.$data.animatedTime, {
+        duration: 0.6,
+        minutes: newMinutes,
+      });
     },
   },
 };
 </script>
 
-<style></style>
+<style lang="scss" scoped>
+.play-time {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: 0.125rem;
+  row-gap: 0.375rem;
+  align-items: flex-end;
+}
+</style>

--- a/src/components/PlayCountCard.vue
+++ b/src/components/PlayCountCard.vue
@@ -1,14 +1,7 @@
 <template>
   <VCard class="px-2 py-4">
     <div
-      class="
-        text-center
-        mb-4
-        text-h6
-        font-weight-regular
-        grey--text
-        text--darken-3
-      "
+      class="text-center mb-4 text-h6 font-weight-regular grey--text text--darken-3"
     >
       {{ $t("stats.count.playCount.before") }}
       <span

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -371,7 +371,10 @@
 			},
 			"playTime": {
 				"before": "Good for",
-				"after": "of listening time."
+				"after": "of listening time.",
+				"days": "Days | Day | Days",
+				"hours": "Hours | Hour | Hours",
+				"minutes": "Minutes | Minute | Minutes"
 			}
 		},
 		"percentageLibraryPlayed": "Percentage of library that you listened to",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -364,6 +364,16 @@
 		}
 	},
 	"stats": {
+		"count": {
+			"playCount": {
+				"before": "You have listened to",
+				"after": "songs."
+			},
+			"playTime": {
+				"before": "Good for",
+				"after": "of listening time."
+			}
+		},
 		"percentageLibraryPlayed": "Percentage of library that you listened to",
 		"topTracks": "Top tracks",
 		"useTrackLength": "Use track length"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -367,7 +367,10 @@
 			},
 			"playTime": {
 				"before": "Goed voor",
-				"after": "luistertijd."
+				"after": "luistertijd.",
+				"days": "Dagen | Dag | Dagen",
+				"hours": "Uren | Uur | Uren",
+				"minutes": "Minuten | Minuut | Minuten"
 			}
 		},
 		"percentageLibraryPlayed": "Percentage van muziekbibliotheek dat je besluisterd hebt:",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -360,6 +360,16 @@
 		}
 	},
 	"stats": {
+		"count": {
+			"playCount": {
+				"before": "Je hebt",
+				"after": "nummers beluisterd."
+			},
+			"playTime": {
+				"before": "Goed voor",
+				"after": "luistertijd."
+			}
+		},
 		"percentageLibraryPlayed": "Percentage van muziekbibliotheek dat je besluisterd hebt:",
 		"topTracks": "Meest besluisterde nummers",
 		"useTrackLength": "Volgens lengte nummers"

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -13,25 +13,26 @@
         <DateRangeSelect @input="(e) => (period = e)" />
       </VCol>
     </VRow>
-    <VRow>
-      <VCol cols="12" md="9">
-        <TopTracksList
-          class="stats__top-tracks"
-          :plays="filteredPlays"
-          :use-track-length="useTrackLength"
-          :title="$t('stats.topTracks')"
-        />
-      </VCol>
-      <VCol cols="12" md="3">
-        <PercentagePlayedCard
-          class="stats__percentage-played"
-          :plays="filteredPlays"
-          :use-track-length="useTrackLength"
-          :tracks="tracks"
-          :title="$t('stats.percentageLibraryPlayed')"
-        />
-      </VCol>
-    </VRow>
+    <div class="stats">
+      <PlayCountCard
+        :plays="filteredPlays"
+        title=""
+        class="stats__play-count"
+      />
+      <TopTracksList
+        class="stats__top-tracks"
+        :plays="filteredPlays"
+        :use-track-length="useTrackLength"
+        :title="$t('stats.topTracks')"
+      />
+      <PercentagePlayedCard
+        class="stats__percentage-played"
+        :plays="filteredPlays"
+        :use-track-length="useTrackLength"
+        :tracks="tracks"
+        :title="$t('stats.percentageLibraryPlayed')"
+      />
+    </div>
   </VContainer>
 </template>
 
@@ -39,6 +40,7 @@
 import { mapGetters, mapState } from "vuex";
 import DateRangeSelect from "@/components/DateRangeSelect";
 import PercentagePlayedCard from "@/components/PercentagePlayedCard";
+import PlayCountCard from "@/components/PlayCountCard";
 import TopTracksList from "@/components/TopTracksList";
 import { filterPlaysByPeriod } from "@/filters";
 
@@ -50,6 +52,7 @@ export default {
   components: {
     DateRangeSelect,
     PercentagePlayedCard,
+    PlayCountCard,
     TopTracksList,
   },
   data() {
@@ -84,4 +87,38 @@ export default {
 };
 </script>
 
-<style></style>
+<style lang="scss" scoped>
+.stats {
+  display: grid;
+  grid-auto-columns: 1fr;
+  gap: 1rem;
+  grid-template-areas:
+    "playCount"
+    "topTracks"
+    "percentagePlayed";
+
+  @media (min-width: map-get($grid-breakpoints, "sm")) {
+    grid-template-areas:
+      "topTracks topTracks"
+      "playCount percentagePlayed";
+  }
+
+  @media (min-width: map-get($grid-breakpoints, "md")) {
+    grid-template-areas:
+      "topTracks topTracks playCount"
+      "topTracks topTracks percentagePlayed";
+  }
+
+  &__percentage-played {
+    grid-area: percentagePlayed;
+  }
+
+  &__play-count {
+    grid-area: playCount;
+  }
+
+  &__top-tracks {
+    grid-area: topTracks;
+  }
+}
+</style>


### PR DESCRIPTION
Adds an extra card to Stats, showing:
* The number of plays for this period
* The days/hours/minutes/listened
<img width="383" alt="Screenshot 2021-12-24 at 11 00 12" src="https://user-images.githubusercontent.com/48474670/147343031-80db72ca-cb76-4466-a6e0-8f76d71c73e6.png">

Due to this extra card The current way of handling the layout of stats became overly complicated. I've switched this to use `grid-template-areas` so that we can easily decide on the placement and size of each card in different screensizes.

<img width="917" alt="Screenshot 2021-12-24 at 11 11 11" src="https://user-images.githubusercontent.com/48474670/147343722-2449a6c7-0252-4d4e-9c8e-2e2e97984745.png">
