### PR TITLE
Pause player when pressing spacebar

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -63,7 +63,7 @@
           <VIcon>mdi-skip-previous</VIcon>
         </VBtn>
         <VBtn
-          @click="setPlaying(!playing)"
+          @click="togglePlaying()"
           :disabled="!playlistTracks.length"
           icon
           class="controls__button"
@@ -173,9 +173,7 @@ export default {
     }
     window.addEventListener("keydown", (e) => {
       if (e.code === "Space") {
-        if (this.playlistTracks.length > 0) {
-          this.setPlaying(!this.playing);
-        }
+        this.togglePlaying();
         // prevent window from scrolling down
         e.preventDefault();
       }
@@ -316,6 +314,7 @@ export default {
   },
   methods: {
     ...mapActions("plays", { createPlay: "create" }),
+    ...mapActions("player", ["togglePlaying"]),
     ...mapMutations("player", [
       "setSeekTime",
       "seek",

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -171,6 +171,15 @@ export default {
         this.setPlaying(false);
       });
     }
+    window.addEventListener("keydown", (e) => {
+      if (e.code === "Space") {
+        if (this.playlistTracks.length > 0) {
+          this.setPlaying(!this.playing);
+        }
+        // prevent window from scrolling down
+        e.preventDefault();
+      }
+    });
   },
   beforeDestroy() {
     clearInterval(this.intervalId);

--- a/src/store/player.js
+++ b/src/store/player.js
@@ -71,10 +71,12 @@ export default {
       state.doSeek = true;
     },
     setPlaying(state, val) {
-      if (state.current === -1 && state.playlist.length) {
-        state.current = 0;
+      if (state.playlist.length) {
+        if (state.current === -1) {
+          state.current = 0;
+        }
+        state.playing = val;
       }
-      state.playing = val;
     },
     nextTrack(state) {
       state.current += 1;
@@ -161,6 +163,11 @@ export default {
       return (
         getters.currentTrack && `${tracks}${getters.currentTrack.id}${params}`
       );
+    },
+  },
+  actions: {
+    togglePlaying({ commit, state }) {
+      commit("setPlaying", !state.playing);
     },
   },
 };


### PR DESCRIPTION
This lets the `Player` component listen to key events and pause/unpause the player when the spacebar is pressed. If the playlist is finished (but not empty), pressing spacebar will start playing the playlist from the beginning. It essentially mimics clicking the play/pause button.

It will also prevent the webpage from scrolling down (default browser behavior).

<!---
  Thanks for contributing to Accentor!  Make sure all GitHub actions
  (lint & build) will pass and fill out the template.

  If any changes to your PR are necessary, we will ask for them
  throughout the review process.
  --->
 
<!---
  Please include a summary of the change and which issue is
  fixed. Please also include relevant motivation and context. If your
  pull request includes visual changes (which will probably be the
  case for anything that isn't a pure logic fix), please include
  screenshots showing those changes. Note that the GitHub ToS requires
  you to have the intellectual property rights required to post
  copyrighted content, which you might not have for cover art included
  in your screenshot depending on your jurisdiction and the license
  of the cover art: https://docs.github.com/en/github/site-policy/github-terms-of-service#d-user-generated-content
  --->

<!---
  If you did any manual testing (please do so), describe here what you
  tested and how. Provide instructions so that your tests can be
  easily run again by a maintainer.
  --->
- [x] Tested if pausing works 
- [x] Tested if unpausing works
- [x] Tested if there are no errors when the playlist is empty
