### PR TITLE
Add punchcard to stats

### DIFF
--- a/src/components/PlaysPunchcard.vue
+++ b/src/components/PlaysPunchcard.vue
@@ -1,0 +1,124 @@
+<template>
+  <VCard class="pa-2">
+    <VCardTitle> {{ title }}</VCardTitle>
+    <!-- 
+      The viewbox represents:
+      24 * 22 (For the dots) + 25 (for the y-axis) + 11 (for the final x-axis label)
+      by
+      7 * 22 (for the dots) + 10 (for the x-axis)
+     -->
+    <svg viewBox="0 0 569 174" class="punchcard mx-4 mt-1">
+      <!-- Offset 11 (half dot) + 1 (to visually center) -->
+      <g y-axis transform="translate(0,12)">
+        <text
+          class="grey--text text--darken-2 text-caption"
+          fill="currentColor"
+          x="28"
+          :y="2 + 22 * index"
+          text-anchor="end"
+          v-for="(label, index) in yLabels"
+          :key="label"
+        >
+          {{ label }}
+        </text>
+      </g>
+      <!-- Offset 40 (for y axis) by 176 (area for dots) -->
+      <g x-axis transform="translate(30,164)">
+        <text
+          :x="hour * 22"
+          y="5"
+          :text-anchor="
+            index === 0
+              ? 'start'
+              : index === xLabels.length - 1
+              ? 'end'
+              : 'middle'
+          "
+          fill="currentColor"
+          class="grey--text text--darken-2 text-caption"
+          v-for="(hour, index) in xLabels"
+          :key="hour"
+        >
+          {{ hour }}
+        </text>
+      </g>
+      <!-- Move all dots to the appropriate area: offset for y axis and half dot in each direction -->
+      <g transform="translate(41,11)">
+        <circle
+          class="punchcard__dot primary--text text--darken-1"
+          :cx="hour.cx"
+          :cy="hour.cy"
+          :r="hour.r"
+          v-for="(hour, index) in svgData"
+          :key="index"
+          fill="currentColor"
+        />
+      </g>
+    </svg>
+  </VCard>
+</template>
+
+<script>
+import { mapState } from "vuex";
+import { calcPlayCountForHours, calcPlayTimeForHours } from "@/reducers";
+
+export default {
+  name: "PlaysPunchcard",
+  props: {
+    plays: {
+      type: Array,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    useTrackLength: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      yLabels: [
+        this.$t("common.shortWeekdays.monday"),
+        this.$t("common.shortWeekdays.tuesday"),
+        this.$t("common.shortWeekdays.wednesday"),
+        this.$t("common.shortWeekdays.thursday"),
+        this.$t("common.shortWeekdays.friday"),
+        this.$t("common.shortWeekdays.saturday"),
+        this.$t("common.shortWeekdays.sunday"),
+      ],
+      xLabels: [0, 6, 12, 18, 24],
+    };
+  },
+  computed: {
+    ...mapState("tracks", ["tracks"]),
+    binnedPlays() {
+      const bin = this.useTrackLength
+        ? calcPlayTimeForHours(this.plays, this.tracks)
+        : calcPlayCountForHours(this.plays);
+      return bin;
+    },
+    svgData() {
+      const max = Math.max(...this.binnedPlays);
+      const dots = [];
+      this.binnedPlays.forEach((count, index) => {
+        // We only want to keep/render all the hours where there is at least one play
+        if (count) {
+          // The radius of each dot ranges between 1 and 11
+          const radius = Math.ceil((count / max) * 10000) / 1000 + 1;
+          dots.push({
+            cx: 22 * (index % 24),
+            cy: 22 * Math.floor(index / 24),
+            r: radius,
+          });
+        }
+      });
+      return dots;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/PlaysPunchcard.vue
+++ b/src/components/PlaysPunchcard.vue
@@ -46,10 +46,10 @@
       <g transform="translate(41,11)">
         <circle
           class="punchcard__dot primary--text text--darken-1"
-          :cx="hour.cx"
-          :cy="hour.cy"
-          :r="hour.r"
-          v-for="(hour, index) in svgData"
+          :cx="dot.cx"
+          :cy="dot.cy"
+          :r="dot.r"
+          v-for="(dot, index) in svgData"
           :key="index"
           fill="currentColor"
         />

--- a/src/components/PlaysPunchcard.vue
+++ b/src/components/PlaysPunchcard.vue
@@ -1,6 +1,6 @@
 <template>
   <VCard class="pa-2">
-    <VCardTitle> {{ title }}</VCardTitle>
+    <VCardTitle>{{ title }}</VCardTitle>
     <!-- 
       The viewbox represents:
       24 * 22 (For the dots) + 30 (for the y-axis) + 11 (for the final x-axis label)

--- a/src/components/PlaysPunchcard.vue
+++ b/src/components/PlaysPunchcard.vue
@@ -3,7 +3,7 @@
     <VCardTitle> {{ title }}</VCardTitle>
     <!-- 
       The viewbox represents:
-      24 * 22 (For the dots) + 25 (for the y-axis) + 11 (for the final x-axis label)
+      24 * 22 (For the dots) + 30 (for the y-axis) + 11 (for the final x-axis label)
       by
       7 * 22 (for the dots) + 10 (for the x-axis)
      -->

--- a/src/components/PlaysPunchcard.vue
+++ b/src/components/PlaysPunchcard.vue
@@ -7,7 +7,7 @@
       by
       7 * 22 (for the dots) + 10 (for the x-axis)
      -->
-    <svg viewBox="0 0 569 174" class="punchcard mx-4 mt-1">
+    <svg viewBox="0 0 569 174" class="mx-4 mt-1">
       <!-- Offset 11 (half dot) + 1 (to visually center) -->
       <g y-axis transform="translate(0,12)">
         <text
@@ -45,7 +45,7 @@
       <!-- Move all dots to the appropriate area: offset for y axis and half dot in each direction -->
       <g transform="translate(41,11)">
         <circle
-          class="punchcard__dot primary--text text--darken-1"
+          class="primary--text text--darken-1"
           :cx="dot.cx"
           :cy="dot.cy"
           :r="dot.r"

--- a/src/components/PlaysPunchcard.vue
+++ b/src/components/PlaysPunchcard.vue
@@ -107,7 +107,8 @@ export default {
         // We only want to keep/render all the hours where there is at least one play
         if (count) {
           // The radius of each dot ranges between 1 and 11
-          const radius = Math.ceil((count / max) * 10000) / 1000 + 1;
+          const radius =
+            Math.ceil((Math.sqrt(count) / Math.sqrt(max)) * 10000) / 1000 + 1;
           dots.push({
             cx: 22 * (index % 24),
             cy: 22 * Math.floor(index / 24),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,6 +62,15 @@
 		"replace": "Replace",
 		"search": "Search",
 		"settings": "Settings",
+		"shortWeekdays": {
+			"monday": "Mon",
+			"tuesday": "Tue",
+			"wednesday": "Wed",
+			"thursday": "Thu",
+			"friday": "Fri",
+			"saturday": "Sat",
+			"sunday": "Sun"
+		},
 		"stats": "Stats",
 		"stats-for-artist": "Stats for {artist}",
 		"yes": "Yes"
@@ -380,6 +389,7 @@
 		},
 		"percentageArtistPlayed": "Percentage of {artist} that you listened to",
 		"percentageLibraryPlayed": "Percentage of library that you listened to",
+		"punchcard": "When do you listen to music?",
 		"topAlbums": "Top albums",
 		"topArtists": "Top artists",
 		"topTracks": "Top tracks",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -62,6 +62,15 @@
 		"replace": "Vervangen",
 		"search": "Zoeken",
 		"settings": "Instellingen",
+		"shortWeekdays": {
+			"monday": "Maa",
+			"tuesday": "Din",
+			"wednesday": "Woe",
+			"thursday": "Don",
+			"friday": "Vrij",
+			"saturday": "Zat",
+			"sunday": "Zon"
+		},
 		"stats": "Statistieken",
 		"stats-for-artist": "Statistieken voor {artist}",
 		"yes": "Ja"
@@ -376,6 +385,7 @@
 		},
 		"percentageArtistPlayed": "Percentage van {artist} dat je beluisterd hebt:",
 		"percentageLibraryPlayed": "Percentage van muziekbibliotheek dat je beluisterd hebt:",
+		"punchcard": "Wanneer luister je naar muziek?",
 		"topAlbums": "Meest besluisterde albums",
 		"topArtists": "Meest besluisterde artiesten",
 		"topTracks": "Meest besluisterde nummers",

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -108,3 +108,41 @@ export function calcPlayTimeForArtists(plays, tracks) {
   }
   return acc;
 }
+
+export function calcPlayCountForHours(plays) {
+  const acc = new Array(168).fill(0);
+  for (const play of plays) {
+    const playedAt = new Date(play.played_at);
+    const day = playedAt.getDay();
+    const hour = playedAt.getHours();
+    acc[day * 24 + hour]++;
+  }
+  // Put sunday last
+  acc.push(...acc.splice(0, 24));
+  return acc;
+}
+
+export function calcPlayTimeForHours(plays, tracks) {
+  const binnedByTrack = {};
+  for (const play of plays) {
+    if (!binnedByTrack[play.track_id]) {
+      binnedByTrack[play.track_id] = [play];
+    } else {
+      binnedByTrack[play.track_id].push(play);
+    }
+  }
+
+  const acc = new Array(168).fill(0);
+  for (const track_id in binnedByTrack) {
+    const length = tracks[track_id]?.length || 0;
+    for (const play of binnedByTrack[track_id]) {
+      const playedAt = new Date(play.played_at);
+      const day = playedAt.getDay();
+      const hour = playedAt.getHours();
+      acc[day * 24 + hour] += length;
+    }
+  }
+  // Put sunday last
+  acc.push(...acc.splice(0, 24));
+  return acc;
+}

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -49,6 +49,12 @@
         :use-track-length="useTrackLength"
         :title="$t('stats.topArtists')"
       />
+      <PlaysPunchcard
+        class="stats__punchcard"
+        :plays="filteredPlays"
+        :use-track-length="useTrackLength"
+        :title="$t('stats.punchcard')"
+      />
     </div>
   </VContainer>
 </template>
@@ -58,6 +64,7 @@ import { mapGetters, mapState } from "vuex";
 import DateRangeSelect from "@/components/DateRangeSelect";
 import PercentagePlayedCard from "@/components/PercentagePlayedCard";
 import PlayCountCard from "@/components/PlayCountCard";
+import PlaysPunchcard from "@/components/PlaysPunchcard";
 import TopArtistsList from "@/components/TopArtistsList";
 import TopTracksList from "@/components/TopTracksList";
 import TopAlbumsList from "@/components/TopAlbumsList";
@@ -72,6 +79,7 @@ export default {
     DateRangeSelect,
     PercentagePlayedCard,
     PlayCountCard,
+    PlaysPunchcard,
     TopAlbumsList,
     TopArtistsList,
     TopTracksList,
@@ -167,21 +175,24 @@ export default {
     "topTracks"
     "percentagePlayed"
     "topAlbums"
-    "topArtists";
+    "topArtists"
+    "punchcard";
 
   @media (min-width: map-get($grid-breakpoints, "sm")) {
     grid-template-areas:
       "topTracks topTracks"
       "playCount percentagePlayed"
       "topAlbums topAlbums"
-      "topArtists topArtists";
+      "topArtists topArtists"
+      "punchcard punchcard";
   }
 
   @media (min-width: map-get($grid-breakpoints, "md")) {
     grid-template-areas:
       "topTracks topTracks topTracks topTracks playCount playCount"
       "topTracks topTracks topTracks topTracks percentagePlayed percentagePlayed"
-      "topAlbums topAlbums topAlbums topArtists topArtists topArtists";
+      "topAlbums topAlbums topAlbums topArtists topArtists topArtists"
+      "punchcard punchcard punchcard punchcard punchcard punchcard";
   }
 
   &__percentage-played {
@@ -202,6 +213,10 @@ export default {
 
   &__top-artists {
     grid-area: topArtists;
+  }
+
+  &__punchcard {
+    grid-area: punchcard;
   }
 }
 </style>


### PR DESCRIPTION
Adds a simple punchard to the stats, showing when in the week a user listens to music.
If there are no plays for an hour, nothing in shown. For hours where there is at least on play, the dots range between a radius of 1 and 11 (in the svg grid) - relative the the hour with the highest count.

I've left a few comments in the svg, to make sure we can remember where some of the numbers come from.

<img width="903" alt="Screenshot 2021-12-29 at 12 50 31" src="https://user-images.githubusercontent.com/48474670/147660440-fa889fe8-e45a-486f-9103-2e654c474f51.png">
