### PR TITLE
Fix TopList readability

### DIFF
--- a/src/components/TopAlbumsList.vue
+++ b/src/components/TopAlbumsList.vue
@@ -12,53 +12,17 @@
         />
       </VCol>
     </VRow>
-    <ol class="top-list">
-      <li v-for="(item, index) in listData" :key="index" class="top-item">
-        <VImg :src="item.image" class="top-item__cover" />
-        <div class="top-item__stat">
-          <span class="top-item__text">
-            <span class="top-item__position font-weight-medium">
-              {{ index + 1 }}.
-            </span>
-            <span class="top-item__name">
-              {{ item.albumArtists.map((a) => a.name).join(" / ") }}
-              - {{ item.title }}
-            </span>
-          </span>
-          <div class="top-item__bg-wrapper">
-            <div
-              class="top-item__bg primary"
-              :style="{ width: `${animatedWidths[index]}%` }"
-            >
-              <span
-                class="top-item__count font-weight-medium white--text"
-                v-if="useAverage"
-              >
-                {{ item.count.toFixed(2) }}
-              </span>
-              <span
-                class="top-item__count font-weight-medium white--text"
-                v-else-if="useTrackLength"
-              >
-                {{ item.count | length }}
-              </span>
-              <span
-                class="top-item__count font-weight-medium white--text"
-                v-else
-              >
-                {{ item.count }}
-              </span>
-            </div>
-          </div>
-        </div>
-      </li>
-    </ol>
+    <TopList
+      :list-data="listData"
+      :show-length="!useAverage && useTrackLength"
+    />
   </VCard>
 </template>
 
 <script>
 import { mapState } from "vuex";
 import { calcPlayCountForAlbums, calcPlayTimeForAlbums } from "@/reducers";
+import TopList from "@/components/TopList";
 
 export default {
   name: "TopAlbumsList",
@@ -78,9 +42,11 @@ export default {
   },
   data() {
     return {
-      animatedWidths: Array(10).fill(0),
       useAverage: true,
     };
+  },
+  components: {
+    TopList,
   },
   computed: {
     ...mapState("albums", ["albums"]),
@@ -95,82 +61,22 @@ export default {
         .slice(0, 10);
     },
     listData() {
-      const max = (this.topAlbums[0] && this.topAlbums[0][1]) || 0;
       return [...this.topAlbums].map((tt) => {
         const album = this.albums[tt[0]];
+        const albumArtists = album?.album_artists
+          .map((aa) => aa)
+          .sort((a1, a2) => a1.order - a2.order)
+          .map((a) => a.name)
+          .join(" / ");
         return {
-          count: tt[1],
-          title: album?.title,
-          width: (tt[1] * 100.0) / max,
+          count: this.useAverage ? tt[1].toFixed(2) : tt[1],
+          label: `${albumArtists} - ${album?.title}`,
           image: album?.image100 || require("@mdi/svg/svg/album.svg"),
-          albumArtists:
-            album?.album_artists
-              .map((aa) => aa)
-              .sort((a1, a2) => a1.order - a2.order) || [],
         };
       });
-    },
-  },
-  watch: {
-    listData() {
-      setTimeout(() => {
-        this.animatedWidths = this.listData.map((i) => i.width);
-      }, 0);
     },
   },
 };
 </script>
 
-<style lang="scss" scoped>
-.top-list {
-  list-style: none;
-  padding-left: 0;
-}
-
-.top-item {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  padding: 0.375rem 1rem;
-
-  &__cover {
-    flex-grow: 0;
-    object-fit: cover;
-    height: 6rem;
-    width: 6rem;
-    margin-right: 1rem;
-  }
-
-  &__stat {
-    flex-grow: 1;
-  }
-
-  &__bg-wrapper {
-    width: 100%;
-    height: 2rem;
-  }
-
-  &__bg {
-    height: 100%;
-    border-radius: 0.5rem;
-    transition-property: width;
-    transition-timing-function: ease-in-out;
-    transition-duration: 500ms;
-  }
-
-  &__text {
-    display: flex;
-    line-height: 1.2;
-    margin-bottom: 0.125rem;
-  }
-
-  &__position {
-    margin-right: 0.25rem;
-  }
-
-  &__count {
-    float: right;
-    padding: 0.25rem 0.5rem;
-  }
-}
-</style>
+<style></style>

--- a/src/components/TopArtistsList.vue
+++ b/src/components/TopArtistsList.vue
@@ -1,46 +1,14 @@
 <template>
   <VCard class="pa-2">
     <VCardTitle>{{ title }}</VCardTitle>
-    <ol class="top-list">
-      <li v-for="(item, index) in listData" :key="index" class="top-item">
-        <VImg :src="item.image" class="top-item__cover" />
-        <div class="top-item__stat">
-          <span class="top-item__text">
-            <span class="top-item__position font-weight-medium">
-              {{ index + 1 }}.
-            </span>
-            <span class="top-item__name">
-              {{ item.name }}
-            </span>
-          </span>
-          <div class="top-item__bg-wrapper">
-            <div
-              class="top-item__bg primary"
-              :style="{ width: `${animatedWidths[index]}%` }"
-            >
-              <span
-                class="top-item__count font-weight-medium white--text"
-                v-if="useTrackLength"
-              >
-                {{ item.count | length }}
-              </span>
-              <span
-                class="top-item__count font-weight-medium white--text"
-                v-else
-              >
-                {{ item.count }}
-              </span>
-            </div>
-          </div>
-        </div>
-      </li>
-    </ol>
+    <TopList :list-data="listData" :show-length="useTrackLength" />
   </VCard>
 </template>
 
 <script>
 import { mapState } from "vuex";
 import { calcPlayCountForArtists, calcPlayTimeForArtists } from "@/reducers";
+import TopList from "@/components/TopList";
 
 export default {
   name: "TopArtistsList",
@@ -58,10 +26,8 @@ export default {
       default: false,
     },
   },
-  data() {
-    return {
-      animatedWidths: Array(10).fill(0),
-    };
+  components: {
+    TopList,
   },
   computed: {
     ...mapState("artists", ["artists"]),
@@ -76,77 +42,17 @@ export default {
         .slice(0, 10);
     },
     listData() {
-      const max = (this.topTracks[0] && this.topTracks[0][1]) || 0;
       return [...this.topTracks].map((tt) => {
         const artist = this.artists[tt[0]];
         return {
           count: tt[1],
-          name: artist?.name,
-          width: (tt[1] * 100.0) / max,
+          label: artist?.name,
           image: artist?.image100 || require("@mdi/svg/svg/account-music.svg"),
         };
       });
     },
   },
-  watch: {
-    listData() {
-      setTimeout(() => {
-        this.animatedWidths = this.listData.map((i) => i.width);
-      }, 0);
-    },
-  },
 };
 </script>
 
-<style lang="scss" scoped>
-.top-list {
-  list-style: none;
-  padding-left: 0;
-}
-
-.top-item {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  padding: 0.375rem 1rem;
-
-  &__cover {
-    flex-grow: 0;
-    object-fit: cover;
-    height: 6rem;
-    width: 6rem;
-    margin-right: 1rem;
-  }
-
-  &__stat {
-    flex-grow: 1;
-  }
-  &__bg-wrapper {
-    width: 100%;
-    height: 2rem;
-  }
-
-  &__bg {
-    height: 100%;
-    border-radius: 0.5rem;
-    transition-property: width;
-    transition-timing-function: ease-in-out;
-    transition-duration: 500ms;
-  }
-
-  &__text {
-    display: flex;
-    line-height: 1.2;
-    margin-bottom: 0.125rem;
-  }
-
-  &__position {
-    margin-right: 0.25rem;
-  }
-
-  &__count {
-    float: right;
-    padding: 0.25rem 0.5rem;
-  }
-}
-</style>
+<style></style>

--- a/src/components/TopList.vue
+++ b/src/components/TopList.vue
@@ -12,6 +12,26 @@
           </span>
         </span>
         <div class="top-item__bg-wrapper">
+          <span
+            class="
+              top-item__count top-item__count--backup
+              font-weight-medium
+              black--text
+            "
+            v-if="showLength"
+          >
+            {{ item.count | length }}
+          </span>
+          <span
+            class="
+              top-item__count top-item__count--backup
+              font-weight-medium
+              black--text
+            "
+            v-else
+          >
+            {{ item.count }}
+          </span>
           <div
             class="top-item__bg primary"
             :style="{ width: `${animatedWidths[index]}%` }"
@@ -92,6 +112,7 @@ export default {
   &__bg-wrapper {
     width: 100%;
     height: 2rem;
+    position: relative;
   }
 
   &__bg {
@@ -100,6 +121,10 @@ export default {
     transition-property: width;
     transition-timing-function: ease-in-out;
     transition-duration: 500ms;
+    display: flex;
+    z-index: 1;
+    position: relative;
+    overflow: hidden;
   }
 
   &__text {
@@ -113,8 +138,17 @@ export default {
   }
 
   &__count {
-    float: right;
+    margin-left: auto;
+    white-space: nowrap;
     padding: 0.25rem 0.5rem;
+
+    &--backup {
+      margin-left: 0;
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: 0;
+    }
   }
 }
 </style>

--- a/src/components/TopList.vue
+++ b/src/components/TopList.vue
@@ -13,21 +13,13 @@
         </span>
         <div class="top-item__bg-wrapper">
           <span
-            class="
-              top-item__count top-item__count--backup
-              font-weight-medium
-              primary--text
-            "
+            class="top-item__count top-item__count--backup font-weight-medium primary--text"
             v-if="showLength"
           >
             {{ item.count | length }}
           </span>
           <span
-            class="
-              top-item__count top-item__count--backup
-              font-weight-medium
-              primary--text
-            "
+            class="top-item__count top-item__count--backup font-weight-medium primary--text"
             v-else
           >
             {{ item.count }}

--- a/src/components/TopList.vue
+++ b/src/components/TopList.vue
@@ -12,32 +12,37 @@
           </span>
         </span>
         <div class="top-item__bg-wrapper">
-          <span
-            class="top-item__count top-item__count--backup font-weight-medium primary--text"
-            v-if="showLength"
-          >
-            {{ item.count | length }}
-          </span>
-          <span
-            class="top-item__count top-item__count--backup font-weight-medium primary--text"
-            v-else
-          >
-            {{ item.count }}
-          </span>
           <div
             class="top-item__bg primary"
             :style="{ width: `${animatedWidths[index]}%` }"
           >
             <span
               class="top-item__count font-weight-medium white--text"
-              v-if="showLength"
+              v-if="widths[index] > 10 && showLength"
             >
               {{ item.count | length }}
             </span>
-            <span class="top-item__count font-weight-medium white--text" v-else>
+            <span
+              class="top-item__count font-weight-medium white--text"
+              v-else-if="widths[index] > 10"
+            >
               {{ item.count }}
             </span>
           </div>
+          <span
+            class="top-item__count top-item__count--backup font-weight-medium primary--text"
+            :style="{ 'margin-left': `${animatedWidths[index]}%` }"
+            v-if="widths[index] <= 10 && showLength"
+          >
+            {{ item.count | length }}
+          </span>
+          <span
+            class="top-item__count top-item__count--backup font-weight-medium primary--text"
+            :style="{ 'margin-left': `${animatedWidths[index]}%` }"
+            v-else-if="widths[index] <= 10"
+          >
+            {{ item.count }}
+          </span>
         </div>
       </div>
     </li>

--- a/src/components/TopList.vue
+++ b/src/components/TopList.vue
@@ -16,7 +16,7 @@
             class="
               top-item__count top-item__count--backup
               font-weight-medium
-              black--text
+              primary--text
             "
             v-if="showLength"
           >
@@ -26,7 +26,7 @@
             class="
               top-item__count top-item__count--backup
               font-weight-medium
-              black--text
+              primary--text
             "
             v-else
           >

--- a/src/components/TopList.vue
+++ b/src/components/TopList.vue
@@ -1,0 +1,120 @@
+<template>
+  <ol class="top-list">
+    <li v-for="(item, index) in listData" :key="index" class="top-item">
+      <VImg :src="item.image" class="top-item__cover" v-if="item.image" />
+      <div class="top-item__stat">
+        <span class="top-item__text">
+          <span class="top-item__position font-weight-medium">
+            {{ index + 1 }}.
+          </span>
+          <span class="top-item__name">
+            {{ item.label }}
+          </span>
+        </span>
+        <div class="top-item__bg-wrapper">
+          <div
+            class="top-item__bg primary"
+            :style="{ width: `${animatedWidths[index]}%` }"
+          >
+            <span
+              class="top-item__count font-weight-medium white--text"
+              v-if="showLength"
+            >
+              {{ item.count | length }}
+            </span>
+            <span class="top-item__count font-weight-medium white--text" v-else>
+              {{ item.count }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </li>
+  </ol>
+</template>
+
+<script>
+export default {
+  name: "TopList",
+  props: {
+    listData: {
+      type: Array,
+      required: true,
+    },
+    showLength: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      animatedWidths: Array(10).fill(0),
+    };
+  },
+  computed: {
+    widths() {
+      const max = this.listData[0]?.count;
+      return this.listData.map((i) => (i.count * 100.0) / max);
+    },
+  },
+  watch: {
+    widths() {
+      setTimeout(() => {
+        this.animatedWidths = this.widths;
+      }, 0);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.top-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.top-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 1rem;
+
+  &__cover {
+    flex-grow: 0;
+    object-fit: cover;
+    height: 6rem;
+    width: 6rem;
+    margin-right: 1rem;
+  }
+
+  &__stat {
+    flex-grow: 1;
+  }
+  &__bg-wrapper {
+    width: 100%;
+    height: 2rem;
+  }
+
+  &__bg {
+    height: 100%;
+    border-radius: 0.5rem;
+    transition-property: width;
+    transition-timing-function: ease-in-out;
+    transition-duration: 500ms;
+  }
+
+  &__text {
+    display: flex;
+    line-height: 1.2;
+    margin-bottom: 0.125rem;
+  }
+
+  &__position {
+    margin-right: 0.25rem;
+  }
+
+  &__count {
+    float: right;
+    padding: 0.25rem 0.5rem;
+  }
+}
+</style>

--- a/src/components/TopTracksList.vue
+++ b/src/components/TopTracksList.vue
@@ -1,46 +1,14 @@
 <template>
   <VCard class="pa-2">
     <VCardTitle> {{ title }}</VCardTitle>
-    <ol class="top-list">
-      <li v-for="(item, index) in listData" :key="index" class="top-item">
-        <span class="top-item__text">
-          <span class="top-item__position font-weight-medium">
-            {{ index + 1 }}.
-          </span>
-          <span class="top-item__name">
-            {{
-              item.trackArtists
-                .filter((a) => !a.hidden)
-                .map((a) => a.name)
-                .join(" / ")
-            }}
-            - {{ item.title }}
-          </span>
-        </span>
-        <div class="top-item__bg-wrapper">
-          <div
-            class="top-item__bg primary"
-            :style="{ width: `${animatedWidths[index]}%` }"
-          >
-            <span
-              class="top-item__count font-weight-medium white--text"
-              v-if="useTrackLength"
-            >
-              {{ item.count | length }}
-            </span>
-            <span class="top-item__count font-weight-medium white--text" v-else>
-              {{ item.count }}
-            </span>
-          </div>
-        </div>
-      </li>
-    </ol>
+    <TopList :list-data="listData" :show-length="useTrackLength" />
   </VCard>
 </template>
 
 <script>
 import { mapState } from "vuex";
 import { calcPlayCountForTracks, calcPlayTimeForTracks } from "@/reducers";
+import TopList from "@/components/TopList";
 
 export default {
   name: "TopTracksList",
@@ -58,10 +26,8 @@ export default {
       default: false,
     },
   },
-  data() {
-    return {
-      animatedWidths: Array(10).fill(0),
-    };
+  components: {
+    TopList,
   },
   computed: {
     ...mapState("tracks", ["tracks"]),
@@ -75,68 +41,23 @@ export default {
         .slice(0, 10);
     },
     listData() {
-      const max = (this.topTracks[0] && this.topTracks[0][1]) || 0;
       return [...this.topTracks].map((tt) => {
         const track = this.tracks[tt[0]];
+        const trackArtists = track?.track_artists
+          .filter((a) => !a.hidden)
+          .map((ta) => ta)
+          .sort((a1, a2) => a1.order - a2.order)
+          .map((a) => a.name)
+          .join(" / ");
+        const label = `${trackArtists} - ${track?.title}`;
         return {
           count: tt[1],
-          title: track?.title,
-          width: (tt[1] * 100.0) / max,
-          trackArtists:
-            track?.track_artists
-              .map((ta) => ta)
-              .sort((a1, a2) => a1.order - a2.order) || [],
+          label,
         };
       });
-    },
-  },
-  watch: {
-    listData() {
-      setTimeout(() => {
-        this.animatedWidths = this.listData.map((i) => i.width);
-      }, 0);
     },
   },
 };
 </script>
 
-<style lang="scss" scoped>
-.top-list {
-  list-style: none;
-  padding-left: 0;
-}
-
-.top-item {
-  width: 100%;
-  display: block;
-  padding: 0.375rem 1rem;
-
-  &__bg-wrapper {
-    width: 100%;
-    height: 2rem;
-  }
-
-  &__bg {
-    height: 100%;
-    border-radius: 0.5rem;
-    transition-property: width;
-    transition-timing-function: ease-in-out;
-    transition-duration: 500ms;
-  }
-
-  &__text {
-    display: flex;
-    line-height: 1.2;
-    margin-bottom: 0.125rem;
-  }
-
-  &__position {
-    margin-right: 0.25rem;
-  }
-
-  &__count {
-    float: right;
-    padding: 0.25rem 0.5rem;
-  }
-}
-</style>
+<style></style>


### PR DESCRIPTION
Fixes an issue where only part of the count was readable. I ended up placing a second count behind the bar in black. Since we don't know the width of the bar (in pixels) or the length of the count (in pixels), this seemed like the easier solution to me.

To avoid having to change this for three different places, I also extracted the list to a separate `TopList`-component.

<img width="432" alt="Screenshot 2021-12-29 at 15 12 52" src="https://user-images.githubusercontent.com/48474670/147671073-39897a83-2f2d-47d9-bea2-05d22037954b.png">


