### PR TITLE
Allow play stats for artist

### DIFF
--- a/src/components/ArtistActions.vue
+++ b/src/components/ArtistActions.vue
@@ -10,6 +10,7 @@
       text
       icon
       small
+      v-if="extended"
     >
       <VIcon>mdi-chart-bar</VIcon>
     </VBtn>
@@ -79,6 +80,10 @@ export default {
       type: Object,
       required: true,
     },
+    extended: {
+      type: Boolean,
+      default: false,
+    }
   },
   computed: {
     ...mapGetters("auth", ["isModerator"]),

--- a/src/components/ArtistActions.vue
+++ b/src/components/ArtistActions.vue
@@ -1,5 +1,18 @@
 <template>
   <span class="actions">
+    <VBtn
+      :to="{
+        name: 'stats',
+        query: { artist_id: artist.id },
+      }"
+      color="primary"
+      class="actions__button"
+      text
+      icon
+      small
+    >
+      <VIcon>mdi-chart-bar</VIcon>
+    </VBtn>
     <EditReviewComment :item="artist" :update="flag" />
     <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
       <template v-slot:activator="{ on }">

--- a/src/components/ArtistActions.vue
+++ b/src/components/ArtistActions.vue
@@ -83,7 +83,7 @@ export default {
     extended: {
       type: Boolean,
       default: false,
-    }
+    },
   },
   computed: {
     ...mapGetters("auth", ["isModerator"]),

--- a/src/filters.js
+++ b/src/filters.js
@@ -5,10 +5,8 @@ export function filterPlaysByPeriod(startDate, endDate) {
   };
 }
 
-export function filterPlaysByArtist(tracks, artist_id) {
+export function filterPlaysByTracks(tracks) {
   return function (play) {
-    return tracks[play.track_id]?.track_artists.some(
-      (a) => a.artist_id === artist_id
-    );
+    return tracks.some((t) => t.id === play.track_id);
   };
 }

--- a/src/filters.js
+++ b/src/filters.js
@@ -4,3 +4,11 @@ export function filterPlaysByPeriod(startDate, endDate) {
     return playedAt > startDate && playedAt < endDate;
   };
 }
+
+export function filterPlaysByArtist(tracks, artist_id) {
+  return function (play) {
+    return tracks[play.track_id]?.track_artists.some(
+      (a) => a.artist_id === artist_id
+    );
+  };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -378,6 +378,7 @@
 				"minutes": "Minutes | Minute | Minutes"
 			}
 		},
+		"percentageArtistPlayed": "Percentage of {artist} that you listened to",
 		"percentageLibraryPlayed": "Percentage of library that you listened to",
 		"topAlbums": "Top albums",
 		"topArtists": "Top artists",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,6 +63,7 @@
 		"search": "Search",
 		"settings": "Settings",
 		"stats": "Stats",
+		"stats-for-artist": "Stats for {artist}",
 		"yes": "Yes"
 	},
 	"components": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -374,6 +374,7 @@
 				"minutes": "Minuten | Minuut | Minuten"
 			}
 		},
+		"percentageArtistPlayed": "Percentage van {artist} dat je besluisterd hebt:",
 		"percentageLibraryPlayed": "Percentage van muziekbibliotheek dat je besluisterd hebt:",
 		"topAlbums": "Meest besluisterde albums",
 		"topArtists": "Meest besluisterde artiesten",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -374,8 +374,8 @@
 				"minutes": "Minuten | Minuut | Minuten"
 			}
 		},
-		"percentageArtistPlayed": "Percentage van {artist} dat je besluisterd hebt:",
-		"percentageLibraryPlayed": "Percentage van muziekbibliotheek dat je besluisterd hebt:",
+		"percentageArtistPlayed": "Percentage van {artist} dat je beluisterd hebt:",
+		"percentageLibraryPlayed": "Percentage van muziekbibliotheek dat je beluisterd hebt:",
 		"topAlbums": "Meest besluisterde albums",
 		"topArtists": "Meest besluisterde artiesten",
 		"topTracks": "Meest besluisterde nummers",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -63,6 +63,7 @@
 		"search": "Zoeken",
 		"settings": "Instellingen",
 		"stats": "Statistieken",
+		"stats-for-artist": "Statistieken voor {artist}",
 		"yes": "Ja"
 	},
 	"components": {

--- a/src/router.js
+++ b/src/router.js
@@ -139,6 +139,7 @@ const router = new Router({
           path: "stats",
           name: "stats",
           component: Stats,
+          props: (route) => ({ artist_id: +route.query.artist_id || null }),
         },
         {
           path: "tracks",

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -115,9 +115,17 @@ export default {
         filterPlaysByPeriod(this.period.start, this.period.end)
       );
       if (this.artist_id) {
-        plays = plays.filter(filterPlaysByArtist(this.tracks, this.artist_id));
+        plays = plays.filter(filterPlaysByTracks(this.filteredTracks));
       }
       return plays;
+    },
+    filteredTracks() {
+      if (this.artist_id) {
+        return this.$store.getters["tracks/tracksFilterByArtist"](
+          this.artist_id
+        );
+      }
+      return this.$store.getters["tracks/tracks"];
     },
   },
   methods: {

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -30,7 +30,7 @@
         class="stats__percentage-played"
         :plays="filteredPlays"
         :use-track-length="useTrackLength"
-        :tracks="tracks"
+        :tracks="filteredTracks"
         :title="$t('stats.percentageLibraryPlayed')"
       />
       <TopAlbumsList
@@ -57,7 +57,7 @@ import PlayCountCard from "@/components/PlayCountCard";
 import TopArtistsList from "@/components/TopArtistsList";
 import TopTracksList from "@/components/TopTracksList";
 import TopAlbumsList from "@/components/TopAlbumsList";
-import { filterPlaysByPeriod, filterPlaysByArtist } from "@/filters";
+import { filterPlaysByPeriod, filterPlaysByTracks } from "@/filters";
 
 export default {
   name: "Stats",
@@ -93,7 +93,6 @@ export default {
   computed: {
     ...mapGetters({
       plays: "plays/plays",
-      tracks: "tracks/tracks",
     }),
     ...mapState("artists", ["artists"]),
     artistName() {

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -31,7 +31,11 @@
         :plays="filteredPlays"
         :use-track-length="useTrackLength"
         :tracks="filteredTracks"
-        :title="$t('stats.percentageLibraryPlayed')"
+        :title="
+          artist_id
+            ? $t('stats.percentageArtistPlayed', { artist: artistName })
+            : $t('stats.percentageLibraryPlayed')
+        "
       />
       <TopAlbumsList
         class="stats__top-albums"

--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -2,7 +2,7 @@
   <VContainer>
     <VRow>
       <VCol>
-        <h1 class="text-h4">{{ $t("common.stats") }}</h1>
+        <h1 class="text-h4">{{ pageTitle }}</h1>
         <p class="text-subtitle-1">{{ pageSubtitle }}</p>
       </VCol>
       <VCol class="d-flex justify-end">
@@ -57,12 +57,12 @@ import PlayCountCard from "@/components/PlayCountCard";
 import TopArtistsList from "@/components/TopArtistsList";
 import TopTracksList from "@/components/TopTracksList";
 import TopAlbumsList from "@/components/TopAlbumsList";
-import { filterPlaysByPeriod } from "@/filters";
+import { filterPlaysByPeriod, filterPlaysByArtist } from "@/filters";
 
 export default {
   name: "Stats",
   metaInfo() {
-    return { title: this.$t("common.stats") };
+    return { title: this.pageTitle };
   },
   components: {
     DateRangeSelect,
@@ -81,6 +81,12 @@ export default {
       useTrackLength: false,
     };
   },
+  props: {
+    artist_id: {
+      type: Number,
+      default: null,
+    },
+  },
   created() {
     this.reloadPlays();
   },
@@ -89,7 +95,15 @@ export default {
       plays: "plays/plays",
       tracks: "tracks/tracks",
     }),
-    ...mapState("userSettings", ["locale"]),
+    ...mapState("artists", ["artists"]),
+    artistName() {
+      return this.artist_id && this.artists[this.artist_id]?.name;
+    },
+    pageTitle() {
+      return this.artistName
+        ? this.$t("common.stats-for-artist", { artist: this.artistName })
+        : this.$t("common.stats");
+    },
     pageSubtitle() {
       if (this.period.start && this.period.end) {
         return `${this.period.start.toLocaleDateString()} - ${this.period.end.toLocaleDateString()}`;
@@ -97,9 +111,13 @@ export default {
       return "";
     },
     filteredPlays() {
-      return this.plays.filter(
+      let plays = this.plays.filter(
         filterPlaysByPeriod(this.period.start, this.period.end)
       );
+      if (this.artist_id) {
+        plays = plays.filter(filterPlaysByArtist(this.tracks, this.artist_id));
+      }
+      return plays;
     },
   },
   methods: {

--- a/src/views/artists/Artist.vue
+++ b/src/views/artists/Artist.vue
@@ -24,7 +24,7 @@
           <h2 class="text-h4">{{ artist.name }}</h2>
         </div>
         <div>
-          <ArtistActions :artist="artist" class="actions" extended="true" />
+          <ArtistActions :artist="artist" class="actions" :extended="true" />
         </div>
       </VCol>
     </VRow>

--- a/src/views/artists/Artist.vue
+++ b/src/views/artists/Artist.vue
@@ -24,7 +24,7 @@
           <h2 class="text-h4">{{ artist.name }}</h2>
         </div>
         <div>
-          <ArtistActions :artist="artist" class="actions" />
+          <ArtistActions :artist="artist" class="actions" extended="true" />
         </div>
       </VCol>
     </VRow>


### PR DESCRIPTION
Allow the user to see their play stats per artist.

The layout of the stats page stays the same, just with filtered plays/tracks. Plays are currently only filtered based on the track_artists.

To access this page, I added a stats icon to the `ArtistActions`. I'm unsure if this needs to be shown in both the card and on the artist page, both left it like this for now.

Some screenshots showing all visual changes:
<img width="1385" alt="Screenshot 2021-12-30 at 10 15 24" src="https://user-images.githubusercontent.com/48474670/147738853-0b4eee98-6160-4d68-bb6c-5330e977f1ce.png">
<img width="284" alt="Screenshot 2021-12-30 at 10 16 07" src="https://user-images.githubusercontent.com/48474670/147738857-0b5a17aa-5437-4db7-90ac-d0d1fcb054a4.png">
<img width="499" alt="Screenshot 2021-12-30 at 10 16 14" src="https://user-images.githubusercontent.com/48474670/147738861-0fa8f1ce-fcc2-43aa-ad1a-26e2cd183ecd.png">
<img width="383" alt="Screenshot 2021-12-30 at 10 24 57" src="https://user-images.githubusercontent.com/48474670/147738862-587c21da-12af-4274-994a-e5c2ec35e7f1.png">
