### PR TITLE
Use vue-global-events for global shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lodash.debounce": "^4.0.8",
     "roboto-fontface": "^0.10.0",
     "vue": "^2.6.14",
+    "vue-global-events": "^1.2.1",
     "vue-i18n": "^8.26.7",
     "vue-meta": "^2.4.0",
     "vue-router": "^3.5.3",

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="player" v-click-outside="clickOutside">
+    <GlobalEvents
+      :filter="(event) => !['INPUT', 'TEXTAREA'].includes(event.target.tagName)"
+      @keydown.space.prevent="togglePlaying"
+    />
     <audio ref="audio" @error="onAudioError" />
     <div class="play-queue" v-if="open">
       <table class="play-queue__table">
@@ -136,11 +140,12 @@
 <script>
 import { mapActions, mapGetters, mapMutations, mapState } from "vuex";
 import Draggable from "vuedraggable";
+import GlobalEvents from "vue-global-events";
 import TrackArtists from "./TrackArtists";
 
 export default {
   name: "Player",
-  components: { Draggable, TrackArtists },
+  components: { Draggable, GlobalEvents, TrackArtists },
   data() {
     return {
       open: false,
@@ -171,13 +176,6 @@ export default {
         this.setPlaying(false);
       });
     }
-    window.addEventListener("keydown", (e) => {
-      if (e.code === "Space") {
-        this.togglePlaying();
-        // prevent window from scrolling down
-        e.preventDefault();
-      }
-    });
   },
   beforeDestroy() {
     clearInterval(this.intervalId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2354,9 +2354,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001230"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz#8135c57459854b2240b57a4a6786044bdc5a9f71"
-  integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
+  version "1.0.30001294"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001294.tgz"
+  integrity sha512-LiMlrs1nSKZ8qkNhpUf5KD0Al1KCBE3zaT7OLOwEkagXMEDij98SiOovn9wxVGQpklk9vVC/pUSqgYmkmKOS8g==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -8490,6 +8490,11 @@ vue-eslint-parser@^8.0.1:
     esquery "^1.4.0"
     lodash "^4.17.21"
     semver "^7.3.5"
+
+vue-global-events@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/vue-global-events/-/vue-global-events-1.2.1.tgz#4c1398a1f67854c73290f5c1cedb5109116c2b50"
+  integrity sha512-035Su/+5GUFnj9potJThJXu9DnayRKSENbuBw5k5sMa6hetiY+6Yu+5zUtPXT4X0S9y8tX7uSxGZJMMYiqhFfg==
 
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"


### PR DESCRIPTION
Its `:filter` functionality allows us to make sure `input`s and
`textarea`s can still get the space input when necessary.

<!---
  Thanks for contributing to Accentor!  Make sure all GitHub actions
  (lint & build) will pass and fill out the template.

  If any changes to your PR are necessary, we will ask for them
  throughout the review process.
  --->
 
<!---
  Please include a summary of the change and which issue is
  fixed. Please also include relevant motivation and context. If your
  pull request includes visual changes (which will probably be the
  case for anything that isn't a pure logic fix), please include
  screenshots showing those changes. Note that the GitHub ToS requires
  you to have the intellectual property rights required to post
  copyrighted content, which you might not have for cover art included
  in your screenshot depending on your jurisdiction and the license
  of the cover art: https://docs.github.com/en/github/site-policy/github-terms-of-service#d-user-generated-content
  --->

Fixes #687.

<!---
  If you did any manual testing (please do so), describe here what you
  tested and how. Provide instructions so that your tests can be
  easily run again by a maintainer.
  --->
