### PR TITLE
Allow skipping webpack/babel/eslint cache

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -14,7 +14,23 @@ module.exports = {
       },
     },
   },
+  configureWebpack: (config) => {
+    config.cache = process.env.SKIP_CACHE !== "true";
+  },
   chainWebpack: (config) => {
+    config.module
+      .rule("js")
+      .use("babel-loader")
+      .tap((opt) =>
+        Object.assign(opt, {
+          cacheDirectory: process.env.SKIP_CACHE !== "true",
+        })
+      );
+    config
+      .plugin("eslint")
+      .tap((args) => [
+        Object.assign(args[0], { cache: process.env.SKIP_CACHE !== "true" }),
+      ]);
     ["vue-modules", "vue", "normal-modules", "normal"].forEach((match) => {
       config.module
         .rule("scss")


### PR DESCRIPTION
This is useless in sandbox builds anyway, and specifically tries to write to read-only paths in nix builds.
