### PR TITLE
Show created at with audio file info

### DIFF
--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -104,6 +104,14 @@
                 </VListItemSubtitle>
               </VListItemContent>
             </VListItem>
+            <VListItem>
+              <VListItemContent>
+                <VListItemTitle> {{ $t("common.added-on") }}: </VListItemTitle>
+                <VListItemSubtitle>
+                  {{ $d(new Date(track.created_at), "long") }}
+                </VListItemSubtitle>
+              </VListItemContent>
+            </VListItem>
           </VList>
         </VMenu>
         <VTooltip bottom :disabled="!waitingForReload">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -41,6 +41,7 @@
 	},
 	"common": {
 		"actions": "Actions",
+		"added-on": "Added on",
 		"amount": "Amount",
 		"are-you-sure": "Are you sure?",
 		"as": "as",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -41,6 +41,7 @@
 	},
 	"common": {
 		"actions": "Acties",
+		"added-on": "Toegevoegd op",
 		"amount": "Hoeveelheid",
 		"are-you-sure": "Ben je zeker?",
 		"as": "als",


### PR DESCRIPTION
A small addition to the track's info (only shown to mod+).

I've noticed that this info can be helpful when merging or cleaning up files.

The info now looks like this:
<img width="730" alt="Screenshot 2022-03-26 at 09 58 46" src="https://user-images.githubusercontent.com/48474670/160232486-eb98cc7a-7c4c-4c8f-9734-cc28aa3f9bf6.png">
