### PR TITLE
Don't show edition description if empty string

### DIFF
--- a/src/components/AlbumCard.vue
+++ b/src/components/AlbumCard.vue
@@ -20,7 +20,12 @@
     />
     <VCardTitle class="pb-0 d-block text-truncate" :title="full_title">
       {{ album.title }}&nbsp;
-      <span v-if="album.edition_description !== null" class="grey--text">
+      <span
+        v-if="
+          album.edition_description !== null && album.edition_description.length
+        "
+        class="grey--text"
+      >
         ({{ album.edition_description }})
       </span>
     </VCardTitle>

--- a/src/views/albums/Album.vue
+++ b/src/views/albums/Album.vue
@@ -23,7 +23,13 @@
         <div>
           <div class="text-h4">
             {{ album.title }}
-            <span v-if="album.edition_description !== null" class="grey--text">
+            <span
+              v-if="
+                album.edition_description !== null &&
+                album.edition_description.length
+              "
+              class="grey--text"
+            >
               ({{ album.edition_description }})
             </span>
           </div>


### PR DESCRIPTION
Fixes a few rare occurrences where an album has an edition description, but this is just an empty string. 
Before this fix this would show up as:
<img width="392" alt="Screenshot 2022-03-27 at 13 26 08" src="https://user-images.githubusercontent.com/48474670/160279279-923bba7c-0061-4482-a096-e7750ac3ad9d.png">

(This situation seems to occur when you use the edition description field, but then remove the content again.)