### PR TITLE
Use play stats endpoint in stats page

### DIFF
--- a/src/components/PercentagePlayedCard.vue
+++ b/src/components/PercentagePlayedCard.vue
@@ -39,7 +39,7 @@ import { gsap } from "gsap";
 export default {
   name: "PercentagePlayedCard",
   props: {
-    plays: {
+    playStats: {
       type: Array,
       required: true,
     },
@@ -63,8 +63,7 @@ export default {
   },
   computed: {
     playedTracksInPeriod() {
-      const trackIds = this.plays.map((p) => p.track_id);
-      return [...new Set(trackIds)];
+      return this.playStats.map((p) => p.track_id);
     },
     playedTracksLength() {
       return this.playedTracksInPeriod.reduce((acc, cur) => {

--- a/src/components/PlayCountCard.vue
+++ b/src/components/PlayCountCard.vue
@@ -70,7 +70,7 @@ import { gsap } from "gsap";
 export default {
   name: "PlayCountCard",
   props: {
-    plays: {
+    playStats: {
       type: Array,
       required: true,
     },
@@ -92,12 +92,10 @@ export default {
   computed: {
     ...mapState("tracks", ["tracks"]),
     playCount() {
-      return this.plays.length;
+      return this.playStats.reduce((acc, cur) => acc + cur.count, 0);
     },
     playTime() {
-      return this.plays.reduce((acc, cur) => {
-        return acc + (this.tracks[cur.track_id]?.length || 0);
-      }, 0);
+      return this.playStats.reduce((acc, cur) => acc + cur.total_length, 0);
     },
   },
   watch: {

--- a/src/components/TopAlbumsList.vue
+++ b/src/components/TopAlbumsList.vue
@@ -27,7 +27,7 @@ import TopList from "@/components/TopList";
 export default {
   name: "TopAlbumsList",
   props: {
-    plays: {
+    playStats: {
       type: Array,
       required: true,
     },
@@ -54,8 +54,8 @@ export default {
     topAlbums() {
       return Object.entries(
         this.useTrackLength
-          ? calcPlayTimeForAlbums(this.plays, this.tracks, this.useAverage)
-          : calcPlayCountForAlbums(this.plays, this.tracks, this.useAverage)
+          ? calcPlayTimeForAlbums(this.playStats, this.tracks, this.useAverage)
+          : calcPlayCountForAlbums(this.playStats, this.tracks, this.useAverage)
       )
         .sort((a1, a2) => a2[1] - a1[1])
         .slice(0, 10);

--- a/src/components/TopArtistsList.vue
+++ b/src/components/TopArtistsList.vue
@@ -7,13 +7,13 @@
 
 <script>
 import { mapState } from "vuex";
-import { calcPlayCountForArtists, calcPlayTimeForArtists } from "@/reducers";
+import { calcPlayStatsForArtists } from "@/reducers";
 import TopList from "@/components/TopList";
 
 export default {
   name: "TopArtistsList",
   props: {
-    plays: {
+    playStats: {
       type: Array,
       required: true,
     },
@@ -34,9 +34,11 @@ export default {
     ...mapState("tracks", ["tracks"]),
     topTracks() {
       return Object.entries(
-        this.useTrackLength
-          ? calcPlayTimeForArtists(this.plays, this.tracks)
-          : calcPlayCountForArtists(this.plays, this.tracks)
+        calcPlayStatsForArtists(
+          this.playStats,
+          this.tracks,
+          this.useTrackLength
+        )
       )
         .sort((t1, t2) => t2[1] - t1[1])
         .slice(0, 10);

--- a/src/components/TopTracksList.vue
+++ b/src/components/TopTracksList.vue
@@ -7,13 +7,12 @@
 
 <script>
 import { mapState } from "vuex";
-import { calcPlayCountForTracks, calcPlayTimeForTracks } from "@/reducers";
 import TopList from "@/components/TopList";
 
 export default {
   name: "TopTracksList",
   props: {
-    plays: {
+    playStats: {
       type: Array,
       required: true,
     },
@@ -31,18 +30,17 @@ export default {
   },
   computed: {
     ...mapState("tracks", ["tracks"]),
+    useProp() {
+      return this.useTrackLength ? "total_length" : "count";
+    },
     topTracks() {
-      return Object.entries(
-        this.useTrackLength
-          ? calcPlayTimeForTracks(this.plays, this.tracks)
-          : calcPlayCountForTracks(this.plays)
-      )
-        .sort((t1, t2) => t2[1] - t1[1])
+      return [...this.playStats]
+        .sort((t1, t2) => t2[this.useProp] - t1[this.useProp])
         .slice(0, 10);
     },
     listData() {
       return [...this.topTracks].map((tt) => {
-        const track = this.tracks[tt[0]];
+        const track = this.tracks[tt.track_id];
         const trackArtists = track?.track_artists
           .filter((a) => !a.hidden)
           .map((ta) => ta)
@@ -51,7 +49,7 @@ export default {
           .join(" / ");
         const label = `${trackArtists} - ${track?.title}`;
         return {
-          count: tt[1],
+          count: tt[this.useProp],
           label,
         };
       });

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,36 +1,15 @@
-export function calcPlayCountForTracks(plays) {
+export function calcPlayCountForAlbums(playStats, tracks, useAverage = false) {
   const acc = {};
-  for (const play of plays) {
-    if (!(play.track_id in acc)) {
-      acc[play.track_id] = 1;
-    } else {
-      acc[play.track_id]++;
-    }
-  }
-  return acc;
-}
-
-export function calcPlayTimeForTracks(plays, tracks) {
-  const acc = calcPlayCountForTracks(plays);
-  for (const track_id in acc) {
-    acc[track_id] = acc[track_id] * tracks[track_id]?.length || 0;
-  }
-  return acc;
-}
-
-export function calcPlayCountForAlbums(plays, tracks, useAverage = false) {
-  const playCounts = calcPlayCountForTracks(plays);
-  const acc = {};
-  for (const track_id in playCounts) {
-    const album_id = tracks[track_id]?.album_id;
+  for (const stat of playStats) {
+    const album_id = tracks[stat.track_id]?.album_id;
     if (!album_id) {
       continue;
     }
 
     if (!(album_id in acc)) {
-      acc[album_id] = playCounts[track_id];
+      acc[album_id] = stat.count;
     } else {
-      acc[album_id] += playCounts[track_id];
+      acc[album_id] += stat.count;
     }
   }
 
@@ -44,19 +23,18 @@ export function calcPlayCountForAlbums(plays, tracks, useAverage = false) {
   return acc;
 }
 
-export function calcPlayTimeForAlbums(plays, tracks, useAverage = false) {
-  const playCounts = calcPlayCountForTracks(plays);
+export function calcPlayTimeForAlbums(playStats, tracks, useAverage = false) {
   const acc = {};
-  for (const track_id in playCounts) {
-    const track = tracks[track_id];
-    if (!track) {
+  for (const stat of playStats) {
+    const album_id = tracks[stat.track_id]?.album_id;
+    if (!album_id) {
       continue;
     }
 
-    if (!(track.album_id in acc)) {
-      acc[track.album_id] = playCounts[track_id] * track.length;
+    if (!(album_id in acc)) {
+      acc[album_id] = stat.total_length;
     } else {
-      acc[track.album_id] += playCounts[track_id] * track.length;
+      acc[album_id] += stat.total_length;
     }
   }
 
@@ -73,36 +51,18 @@ export function calcPlayTimeForAlbums(plays, tracks, useAverage = false) {
   return acc;
 }
 
-export function calcPlayCountForArtists(plays, tracks) {
-  const playCounts = calcPlayCountForTracks(plays);
+export function calcPlayStatsForArtists(playStats, tracks, useTrackLength) {
+  const prop = useTrackLength ? "total_length" : "count";
   const acc = {};
-  for (const track_id in playCounts) {
-    const uniqueIds = (tracks[track_id]?.track_artists || [])
+  for (const stat of playStats) {
+    const uniqueIds = (tracks[stat.track_id]?.track_artists || [])
       .map((ta) => ta.artist_id)
       .filter((id, index, list) => list.indexOf(id) == index);
     for (const ta of uniqueIds) {
       if (!(ta in acc)) {
-        acc[ta] = playCounts[track_id];
+        acc[ta] = stat[prop];
       } else {
-        acc[ta] += playCounts[track_id];
-      }
-    }
-  }
-  return acc;
-}
-
-export function calcPlayTimeForArtists(plays, tracks) {
-  const playCounts = calcPlayCountForTracks(plays);
-  const acc = {};
-  for (const track_id in playCounts) {
-    const uniqueIds = (tracks[track_id]?.track_artists || [])
-      .map((ta) => ta.artist_id)
-      .filter((id, index, list) => list.indexOf(id) == index);
-    for (const ta of uniqueIds) {
-      if (!(ta in acc)) {
-        acc[ta] = playCounts[track_id] * tracks[track_id].length;
-      } else {
-        acc[ta] += playCounts[track_id] * tracks[track_id].length;
+        acc[ta] += stat[prop];
       }
     }
   }


### PR DESCRIPTION
Requires/Matches accentor/api#340 accentor/api-client-js#63

This PR uses the new `plays/stats` endpoint of the api and greatly improves the performance of the stats page.

- I've tried to make the changes in the PR limited to using this new endpoint and removing the client-side calculations, without making any other changes.
- I've not yet added the play stats to the store, or used them in other views. The play stats are the page where we need this improvement the most, and I wanted to keep the scope of this PR limited.

This seemed to work well and improve the response times of the stats pages on my development machine. 
@chvp is there a way/an option to try this out with our real data?

## Possible improvements
* [ ] set the `playStats` value after each x fetches of the endpoint. (We currently wait for all stats to be loaded, which becomes longer and longer the more unique tracks a user has listened to in that period)

