### PR TITLE
Refresh playlists on index and show view

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -148,6 +148,7 @@ const router = new Router({
           path: "playlists/:id",
           name: "playlist",
           component: Playlist,
+          props: true,
         },
         {
           path: "playlists/:id/edit",

--- a/src/views/playlists/Playlist.vue
+++ b/src/views/playlists/Playlist.vue
@@ -109,7 +109,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions("playlists", ["index"]),
+    ...mapActions("playlists", ["read"]),
     async fetchContent(newValue, oldValue) {
       // After loading the content, the router will change the id from a string to a number
       // but we don't actually want to load the content twice
@@ -118,7 +118,7 @@ export default {
       }
 
       await this.read(this.id);
-    }
-  }
+    },
+  },
 };
 </script>

--- a/src/views/playlists/Playlist.vue
+++ b/src/views/playlists/Playlist.vue
@@ -68,7 +68,7 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
+import { mapActions, mapState } from "vuex";
 import AlbumCard from "../../components/AlbumCard";
 import ArtistCard from "../../components/ArtistCard";
 import TracksTable from "../../components/TracksTable";
@@ -84,7 +84,13 @@ export default {
   props: {
     id: {
       type: [String, Number],
-      required: false,
+      required: true,
+    },
+  },
+  watch: {
+    id: {
+      handler: "fetchContent",
+      immediate: true,
     },
   },
   mixins: [Paginated],
@@ -102,5 +108,17 @@ export default {
       return this.playlist?.item_ids.map((id) => this[key][id]) || [];
     },
   },
+  methods: {
+    ...mapActions("playlists", ["index"]),
+    async fetchContent(newValue, oldValue) {
+      // After loading the content, the router will change the id from a string to a number
+      // but we don't actually want to load the content twice
+      if (newValue == oldValue) {
+        return;
+      }
+
+      await this.read(this.id);
+    }
+  }
 };
 </script>

--- a/src/views/playlists/Playlists.vue
+++ b/src/views/playlists/Playlists.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script>
-import { mapGetters, mapState } from "vuex";
+import { mapActions, mapGetters, mapState } from "vuex";
 import Paginated from "../../mixins/Paginated";
 import Searchable from "../../mixins/Searchable";
 import PlaylistActions from "../../components/PlaylistActions";
@@ -80,6 +80,9 @@ export default {
     return { title: this.$tc("music.playlists", 2) };
   },
   components: { PlaylistActions },
+  created() {
+    this.fetchContent();
+  },
   mixins: [Paginated, Searchable],
   computed: {
     ...mapState("users", ["users"]),
@@ -108,5 +111,11 @@ export default {
       }
     },
   },
+  methods: {
+    ...mapActions("playlists", ["index"]),
+    async fetchContent() {
+      await this.index();
+    },
+  }
 };
 </script>

--- a/src/views/playlists/Playlists.vue
+++ b/src/views/playlists/Playlists.vue
@@ -116,6 +116,6 @@ export default {
     async fetchContent() {
       await this.index();
     },
-  }
+  },
 };
 </script>


### PR DESCRIPTION
A small improvement to #749 

With this PR we now refresh the data when a users loads the playlists overview or a specific playlist.

There currently wouldn't be another way to do this than reloading all the data (but this fetches a lot more data than necessary).