### PR TITLE
Make sure user can't add double item to playlist

### DIFF
--- a/src/components/AddToPlaylist.vue
+++ b/src/components/AddToPlaylist.vue
@@ -32,7 +32,13 @@
                 :label="$tc('music.playlists', 1)"
                 return-object
                 v-model="selectedPlaylist"
-              />
+              >
+                <template v-slot:item="props">
+                  <VListItem :disabled="props.item.item_ids.includes(item.id)">
+                    {{ props.item.name }}
+                  </VListItem>
+                </template>
+              </VCombobox>
             </VCol>
           </VRow>
         </VContainer>

--- a/src/components/AddToPlaylist.vue
+++ b/src/components/AddToPlaylist.vue
@@ -88,7 +88,7 @@ export default {
     ...mapGetters("auth", ["currentUser"]),
     ...mapGetters("playlists", ["editablePlaylists"]),
     playlistOptions() {
-      return [...this.editablePlaylists].reduce((options, p) => {
+      return structuredClone(this.editablePlaylists).reduce((options, p) => {
         if (p.playlist_type === this.type) {
           p.disabled = p.item_ids.includes(this.item.id);
           options.push(p);

--- a/src/components/AddToPlaylist.vue
+++ b/src/components/AddToPlaylist.vue
@@ -88,7 +88,7 @@ export default {
     ...mapGetters("auth", ["currentUser"]),
     ...mapGetters("playlists", ["editablePlaylists"]),
     playlistOptions() {
-      return this.editablePlaylists.reduce((options, p) => {
+      return [...this.editablePlaylists].reduce((options, p) => {
         if (p.playlist_type === this.type) {
           p.disabled = p.item_ids.includes(this.item.id);
           options.push(p);

--- a/src/components/AddToPlaylist.vue
+++ b/src/components/AddToPlaylist.vue
@@ -33,9 +33,12 @@
                 return-object
                 v-model="selectedPlaylist"
               >
-                <template v-slot:item="props">
-                  <VListItem :disabled="props.item.item_ids.includes(item.id)">
-                    {{ props.item.name }}
+                <template v-slot:item="{ item, on }">
+                  <VListItem :disabled="item.disabled" v-on="on">
+                    {{ item.name }}
+                    <span v-if="item.disabled">
+                      &nbsp;({{ $t("music.playlist.item-already-present") }})
+                    </span>
                   </VListItem>
                 </template>
               </VCombobox>
@@ -85,9 +88,13 @@ export default {
     ...mapGetters("auth", ["currentUser"]),
     ...mapGetters("playlists", ["editablePlaylists"]),
     playlistOptions() {
-      return this.editablePlaylists.filter(
-        (p) => p.playlist_type === this.type
-      );
+      return this.editablePlaylists.reduce((options, p) => {
+        if (p.playlist_type === this.type) {
+          p.disabled = p.item_ids.includes(this.item.id);
+          options.push(p);
+        }
+        return options;
+      }, []);
     },
   },
   methods: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -350,6 +350,7 @@
 			"add": "Add",
 			"add-item": "Add {obj} to playlist",
 			"create": "Create playlist",
+			"item-already-present": "Already present in playlist",
 			"items": "Items | Item | Items",
 			"item_counts": {
 				"album": "0 albums | 1 album | {count} albums",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -147,6 +147,8 @@
 			"ext-blank": "Please fill in an extionsion.",
 			"ext-taken": "This extension is already in use."
 		},
+		"items": "Playlist item",
+		"item-ids-contains-double": "The item you tried to add is already present in this playlist",
 		"label": {
 			"name-blank": "Please fill in a label name."
 		},

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -346,6 +346,7 @@
 			"add": "Voeg toe",
 			"add-item": "Voeg {obj} toe aan afspeellijst",
 			"create": "Maak afspeellijst aan",
+			"item-already-present": "Al aanwezig in deze afspeellijst",
 			"items": "Items | Item | Items",
 			"item_counts": {
 				"album": "0 albums | 1 album | {count} albums",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -143,6 +143,8 @@
 			"ext-blank": "Vul een extensie in.",
 			"ext-taken": "Deze extensie wordt al gebruikt."
 		},
+		"items": "Afspeellijst items",
+		"item-ids-contains-double": "Het item dat je probeerde toevoegen, is al eerder toegevoegd.",
 		"label": {
 			"name-blank": "Vul een naam voor het label in."
 		},


### PR DESCRIPTION
Fixes #819 

This playlist fixes two things around double items in playlists:
* The error returned by the api (see accentor/api#352) is now translated and correctly displayed
* The options that already contain the item are disabled. I've also added a message to explain the disabled state (This message is quite verbose, but I don't mind this)

Since the error should not occur that often anymore, I don't think it's a problem that it is shown in its usual place and not in the dialog.

<img width="605" alt="Screenshot 2022-07-06 at 09 37 12" src="https://user-images.githubusercontent.com/48474670/177497190-384414aa-e1c7-4293-bd9b-a0fd2ff2a853.png">

