### PR TITLE
Sort playlists by name

### DIFF
--- a/src/store/playlists.js
+++ b/src/store/playlists.js
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import api from "@/api";
 import { fetchAll } from "./actions";
+import { compareStrings } from "../comparators";
 
 export default {
   namespaced: true,
@@ -104,6 +105,10 @@ export default {
   },
   getters: {
     playlists: (state) => Object.values(state.playlists),
+    playlistsByName: (state, getters) =>
+      getters.playlists.sort((p1, p2) =>
+        compareStrings(p1.name.toLowerCase(), p2.name.toLowerCase())
+      ),
     editablePlaylists: (state, getters, rootState) =>
       getters.playlists.filter(
         (p) => p.access === "shared" || p.user_id === rootState.auth.user_id

--- a/src/store/playlists.js
+++ b/src/store/playlists.js
@@ -110,7 +110,7 @@ export default {
         compareStrings(p1.name.toLowerCase(), p2.name.toLowerCase())
       ),
     editablePlaylists: (state, getters, rootState) =>
-      getters.playlists.filter(
+      getters.playlistsByName.filter(
         (p) => p.access === "shared" || p.user_id === rootState.auth.user_id
       ),
   },

--- a/src/views/playlists/Playlists.vue
+++ b/src/views/playlists/Playlists.vue
@@ -87,7 +87,7 @@ export default {
   computed: {
     ...mapState("users", ["users"]),
     ...mapGetters("playlists", {
-      playlists: "playlists",
+      playlists: "playlistsByName",
     }),
     filteredItems() {
       return this.playlists.filter(


### PR DESCRIPTION
We currently sort the playlists by id. This PR changes this to sort them by name (case-insensitive)
* in the playlists overview
* in the playlist options when adding an item to a playlist