### PR TITLE
Add playlists to album's and artist's page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -279,6 +279,7 @@
 				"label": "Hide in overview?",
 				"explanation": "If an artist is hidden, they will only be shown in detailed lists."
 			},
+			"in-playlists": "In playlists | In playlist | In playlists",
 			"merge": "Merge artists",
 			"merge-into": "Merge {obj} into",
 			"new": "New artist",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -263,6 +263,7 @@
 			"edition": "Release",
 			"edition-description": "Edition description",
 			"edition-information": "Add edition information",
+			"in-playlists": "In playlists | In playlist | In playlists",
 			"new": "New album",
 			"no-tracks-to-play": "There are no tracks to play",
 			"no-tracks-to-add": "There are no tracks to add",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -259,6 +259,7 @@
 			"edition": "Editie",
 			"edition-description": "Beschrijving editie",
 			"edition-information": "Voeg informatie over deze editie toe",
+			"in-playlists": "In afspeellijsten | In afspeellijst | In afspeellijsten",
 			"new": "Nieuw album",
 			"no-tracks-to-play": "Er zijn geen nummers om af te spelen",
 			"no-tracks-to-add": "Er zijn geen nummers om toe te voegen",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -275,6 +275,7 @@
 				"label": "Verberg in overzicht?",
 				"explanation": "Als een artiest verborgen is, wordt deze alleen getoonde in de detailweergaves."
 			},
+			"in-playlists": "In afspeellijsten | In afspeellijst | In afspeellijsten",
 			"merge": "Artiesten samenvoegen",
 			"merge-into": "Voeg {obj} samen met",
 			"new": "Nieuwe artiest",

--- a/src/store/playlists.js
+++ b/src/store/playlists.js
@@ -113,5 +113,7 @@ export default {
       getters.playlistsByName.filter(
         (p) => p.access === "shared" || p.user_id === rootState.auth.user_id
       ),
+    albumPlaylists: (state, getters) =>
+      getters.playlists.filter((p) => p.playlist_type === "album"),
   },
 };

--- a/src/store/playlists.js
+++ b/src/store/playlists.js
@@ -115,5 +115,7 @@ export default {
       ),
     albumPlaylists: (state, getters) =>
       getters.playlists.filter((p) => p.playlist_type === "album"),
+    artistPlaylists: (state, getters) =>
+      getters.playlists.filter((p) => p.playlist_type === "artist"),
   },
 };

--- a/src/store/playlists.js
+++ b/src/store/playlists.js
@@ -114,8 +114,8 @@ export default {
         (p) => p.access === "shared" || p.user_id === rootState.auth.user_id
       ),
     albumPlaylists: (state, getters) =>
-      getters.playlists.filter((p) => p.playlist_type === "album"),
+      getters.playlistsByName.filter((p) => p.playlist_type === "album"),
     artistPlaylists: (state, getters) =>
-      getters.playlists.filter((p) => p.playlist_type === "artist"),
+      getters.playlistsByName.filter((p) => p.playlist_type === "artist"),
   },
 };

--- a/src/views/albums/Album.vue
+++ b/src/views/albums/Album.vue
@@ -46,6 +46,18 @@
             -
             {{ al.catalogue_number || $t("music.label.catalogue-number-none") }}
           </div>
+          <div class="grey--text mt-4 mb-4" v-if="playlists.length">
+            {{ $tc("music.album.in-playlists", playlists.length) }}
+            <ul>
+              <li v-for="playlist in playlists" :key="playlist.id">
+                <RouterLink
+                  :to="{ name: 'playlist', params: { id: playlist.id } }"
+                >
+                  {{ playlist.name }}
+                </RouterLink>
+              </li>
+            </ul>
+          </div>
           <div>
             <AlbumActions :album="album" class="actions--wide" />
           </div>
@@ -104,6 +116,11 @@ export default {
     album_labels: function () {
       return this.album.album_labels.filter(
         (al) => `${al.label_id}` in this.labels
+      );
+    },
+    playlists: function () {
+      return this.$store.getters["playlists/albumPlaylists"].filter((p) =>
+        p.item_ids.includes(this.album.id)
       );
     },
   },

--- a/src/views/artists/Artist.vue
+++ b/src/views/artists/Artist.vue
@@ -23,6 +23,18 @@
         <div>
           <h2 class="text-h4">{{ artist.name }}</h2>
         </div>
+        <div class="grey--text mt-4 mb-4" v-if="playlists.length">
+          {{ $tc("music.artist.in-playlists", playlists.length) }}
+          <ul>
+            <li v-for="playlist in playlists" :key="playlist.id">
+              <RouterLink
+                :to="{ name: 'playlist', params: { id: playlist.id } }"
+              >
+                {{ playlist.name }}
+              </RouterLink>
+            </li>
+          </ul>
+        </div>
         <div>
           <ArtistActions :artist="artist" class="actions" :extended="true" />
         </div>
@@ -102,6 +114,11 @@ export default {
     },
     artist: function () {
       return this.artists[this.$route.params.id];
+    },
+    playlists: function () {
+      return this.$store.getters["playlists/artistPlaylists"].filter((p) =>
+        p.item_ids.includes(this.artist.id)
+      );
     },
   },
   methods: {


### PR DESCRIPTION
This PR adds a list of playlists to the page for each album/artist. 
I've split up the translations between the album and artist page, so that it would be easier to differentiate between the two in the future.

Example from album's page
<img width="284" alt="Screenshot 2022-07-06 at 14 26 09" src="https://user-images.githubusercontent.com/48474670/177550598-dff8e129-ce94-46d7-8854-3f32606c5a51.png">
