### PR TITLE
Only calculate values of `PlaysPunchcard` when visible

### DIFF
--- a/src/components/PlaysPunchcard.vue
+++ b/src/components/PlaysPunchcard.vue
@@ -1,13 +1,13 @@
 <template>
-  <VCard class="pa-2">
+  <VCard class="pa-2" v-intersect="onIntersect">
     <VCardTitle>{{ title }}</VCardTitle>
     <!-- 
-      The viewbox represents:
-      24 * 22 (For the dots) + 30 (for the y-axis) + 11 (for the final x-axis label)
-      by
-      7 * 22 (for the dots) + 10 (for the x-axis)
-     -->
-    <svg viewBox="0 0 569 174" class="mx-4 mt-1">
+    The viewbox represents:
+    24 * 22 (For the dots) + 30 (for the y-axis) + 11 (for the final x-axis label)
+    by
+    7 * 22 (for the dots) + 10 (for the x-axis)
+    -->
+    <svg viewBox="0 0 569 174" class="mx-4 mt-1" v-if="isIntersecting">
       <!-- Offset 11 (half dot) + 1 (to visually center) -->
       <g y-axis transform="translate(0,12)">
         <text
@@ -90,6 +90,7 @@ export default {
         this.$t("common.shortWeekdays.sunday"),
       ],
       xLabels: [0, 6, 12, 18, 24],
+      isIntersecting: false,
     };
   },
   computed: {
@@ -117,6 +118,13 @@ export default {
         }
       });
       return dots;
+    },
+  },
+  methods: {
+    onIntersect(entries) {
+      // We only have one entry (the `VCard`)
+      // and simply check whether that is intersecting with the viewport
+      this.isIntersecting = entries[0].isIntersecting;
     },
   },
 };


### PR DESCRIPTION
This PR provides a small performance improvement to the stats page.
After #791, the punchcard is the most expensive calculation on the page, since this still requires us to loop over all the plays and all related tracks.

By using [`v-intersect`](https://vuetifyjs.com/en/directives/intersect/#usage) we can delay the calculation of the computed values until the graph is visible on the page. Only when the element is visible do we show the visualisation. If the user changes the date range or switches to `useTrackLength`, the computed values won't change unless/until the component is visible.

Note: Vuetify also provide a `VLazy` component, but this just watches for the first time the component becomes visible (and so would not delay the calculation when the date range changes or the user switches to `useTrackLength`)

## Testing
The easiest way to verify that this works is by adding a `console.log` to the computed values and verifying that it only prints when the component is visible.