### PR TITLE
Fix adding error in player

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -220,7 +220,7 @@ export default {
             });
           }
         } catch (error) {
-          this.commit("addError", error);
+          this.$store.commit("addError", error);
         }
       }
     },


### PR DESCRIPTION
Fix #902 

We refered to `this.commit()`, but this function does not exist inside the player component. I've changed this to `this.$store.commit()`, so will correctly display the error.

TBH: i'm not sure if we need to display this error for the user. This seems to occur mostly when playing the track failed (which we already catch and display). From some usage we'll be able to estimate this better.
