### PR TITLE
Pass `GITHUB_TOKEN` to `install-nix-action`

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:
@@ -26,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -17,6 +17,7 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - uses: cachix/install-nix-action@v18
         with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=channel:nixpkgs-unstable
       - name: Run yarn2nix
         run: nix-shell -p yarn2nix --run "yarn2nix > yarn.nix"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:
@@ -28,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:
@@ -43,6 +47,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
         uses: cachix/cachix-action@v12
         with:


### PR DESCRIPTION
Passing the `GITHUB_TOKEN` to `cachix/install-nix-action` should fix our actions failing due to github's rate limiting.