### PR TITLE
Pin `install-nix-action` to specific commit

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@25d64bbf11b34ad6443b4169002d4a1b163a4b02
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
@@ -27,7 +27,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@25d64bbf11b34ad6443b4169002d4a1b163a4b02
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@25d64bbf11b34ad6443b4169002d4a1b163a4b02
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=channel:nixpkgs-unstable

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@25d64bbf11b34ad6443b4169002d4a1b163a4b02
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
@@ -29,7 +29,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@25d64bbf11b34ad6443b4169002d4a1b163a4b02
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix
@@ -46,7 +46,7 @@ jobs:
     needs: [packages, shell]
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@25d64bbf11b34ad6443b4169002d4a1b163a4b02
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cachix


### PR DESCRIPTION
Followup on #929

The current release of `install-nix-action` does not yet support the `github_access_token` input. 
I've now pinned this action to the last commit (the other option would be to pin to the `main` branch), since this includes those changes
