### PR TITLE
Retry playing audio tracks when loading fails

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -152,6 +152,7 @@ export default {
       volume: 100,
       muted: false,
       intervalId: 0,
+      tries: 0,
     };
   },
   created() {
@@ -183,6 +184,7 @@ export default {
   },
   watch: {
     async currentTrackURL() {
+      this.tries = 0;
       if (this.currentTrackURL === null) {
         return;
       }
@@ -334,11 +336,18 @@ export default {
       }
     },
     onAudioError(event) {
-      if (this.playing && event.srcElement.networkState === 3) {
+      if (!this.playing || event.srcElement.networkState !== 3) {
+        return null;
+      }
+
+      if (this.tries >= 2) {
         this.nextTrack();
         this.$store.commit("addError", {
           playlist: ["player.track-skipped"],
         });
+      } else {
+        this.tries += 1;
+        this.$refs.audio.play();
       }
     },
     updatePlaylist({ newIndex, oldIndex }) {

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -347,7 +347,7 @@ export default {
         });
       } else {
         this.tries += 1;
-        this.$refs.audio.play();
+        setTimeout(() => this.$refs.audio.play(), this.tries * 500);
       }
     },
     updatePlaylist({ newIndex, oldIndex }) {


### PR DESCRIPTION
Fix #909

With these changes, the player will try to load an audio track three times before giving up and going to the next track.

I wasn't yet able to try this in a real life scenario (where such an error might occur). I'll try and use this branch over the next few days, to see if everything works as expected. We might want to wait for these tests before merging.