### PR TITLE
Log errors when they are added to the store

### DIFF
--- a/src/store/store.js
+++ b/src/store/store.js
@@ -27,6 +27,10 @@ const mutations = {
       this.commit("auth/logout");
     }
     state.errors.push(error);
+
+    // We want to log our errors here, to help with debugging
+    // eslint-disable-next-line no-console
+    console.error(error);
   },
   clearErrors(state) {
     state.errors = [];


### PR DESCRIPTION
Fixes #962

This will log all errors to the console, to help with debugging. The only exception are `unauthorized` errors.

In the future, we might want to only log certain errors, but since this depends on detecting whether something is an object, and that object has the right shape, this might become a bit tricky. (Since there is no builtin way to detect objects in JS)