### PR TITLE
Allow moderator and admin to merge albums

### DIFF
--- a/src/components/AlbumActions.vue
+++ b/src/components/AlbumActions.vue
@@ -64,6 +64,14 @@
     <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
       <template v-slot:activator="{ on }">
         <span v-on="on">
+          <AlbumMergeDialog :album="album" :disabled="waitingForReload" />
+        </span>
+      </template>
+      <span>{{ $t("common.disabled-while-loading") }}</span>
+    </VTooltip>
+    <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
+      <template v-slot:activator="{ on }">
+        <span v-on="on">
           <VBtn
             @click.stop.prevent="deleteAlbum"
             :disabled="album.loaded < startLoading"
@@ -86,10 +94,11 @@
 import { mapActions, mapGetters, mapState } from "vuex";
 import EditReviewComment from "./EditReviewComment";
 import AddToPlaylist from "./AddToPlaylist";
+import AlbumMergeDialog from "./AlbumMergeDialog.vue";
 
 export default {
   name: "AlbumActions",
-  components: { AddToPlaylist, EditReviewComment },
+  components: { AddToPlaylist, AlbumMergeDialog, EditReviewComment },
   props: {
     album: {
       type: Object,

--- a/src/components/AlbumMergeDialog.vue
+++ b/src/components/AlbumMergeDialog.vue
@@ -1,0 +1,105 @@
+<template>
+  <VDialog
+    ref="dialogMerge"
+    v-model="mergeModal"
+    v-if="isModerator"
+    width="600px"
+  >
+    <template v-slot:activator="{ on }">
+      <VBtn
+        v-on="on"
+        :disabled="disabled"
+        @click.stop.prevent
+        class="actions__button"
+        color="edit"
+        text
+        icon
+        small
+      >
+        <VIcon>mdi-merge</VIcon>
+      </VBtn>
+    </template>
+    <VCard>
+      <VCardTitle>
+        <span class="text-h5">{{
+          $t("music.albums.merge-into", { obj: album.name })
+        }}</span>
+      </VCardTitle>
+      <VCardText>
+        <VContainer>
+          <VRow>
+            <VCol cols="12">
+              <VCombobox
+                :items="sortedAlbums"
+                :filter="filterTitle"
+                cache-items
+                item-text="title"
+                item-value="id"
+                :label="$tc('music.albums', 1)"
+                return-object
+                v-model="mergeAlbum"
+              />
+            </VCol>
+          </VRow>
+        </VContainer>
+      </VCardText>
+      <VDivider></VDivider>
+      <VCardActions>
+        <VSpacer></VSpacer>
+        <VBtn color="primary" class="ma-2" type="submit" @click="mergeAlbums">
+          {{ $t("music.album.merge") }}
+        </VBtn>
+      </VCardActions>
+    </VCard>
+  </VDialog>
+</template>
+
+<script>
+import { mapActions, mapGetters } from "vuex";
+
+export default {
+  name: "AlbumMergeDialog",
+  props: {
+    disabled: {
+      type: Boolean,
+      required: true,
+    },
+    album: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      mergeAlbum: null,
+      mergeModal: false,
+    };
+  },
+  computed: {
+    ...mapGetters("auth", ["isModerator"]),
+    sortedAlbums() {
+      const getter = this.$store.getters["albums/albumsByTitle"];
+      return getter.filter((a) => {
+        return a.id !== this.album.id;
+      });
+    },
+  },
+  methods: {
+    ...mapActions("albums", ["merge"]),
+    filterTitle(item, queryText) {
+      const search = queryText.toLowerCase();
+      return (
+        item.title.toLowerCase().indexOf(search) > -1 ||
+        item.normalized_title.indexOf(search) > -1
+      );
+    },
+    mergeAlbums() {
+      this.merge({ newID: this.mergeAlbum.id, oldID: this.album.id }).finally(
+        () => {
+          this.mergeModal = false;
+        }
+      );
+    },
+  },
+};
+</script>

--- a/src/components/AlbumMergeDialog.vue
+++ b/src/components/AlbumMergeDialog.vue
@@ -22,7 +22,7 @@
     <VCard>
       <VCardTitle>
         <span class="text-h5">{{
-          $t("music.albums.merge-into", { obj: album.name })
+          $t("music.album.merge-into", { obj: album.name })
         }}</span>
       </VCardTitle>
       <VCardText>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -266,6 +266,8 @@
 			"edition-description": "Edition description",
 			"edition-information": "Add edition information",
 			"in-playlists": "In playlists | In playlist | In playlists",
+			"merge": "Merge albums",
+			"merge-into": "Merge {obj} into",
 			"new": "New album",
 			"no-tracks-to-play": "There are no tracks to play",
 			"no-tracks-to-add": "There are no tracks to add",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -262,6 +262,8 @@
 			"edition-description": "Beschrijving editie",
 			"edition-information": "Voeg informatie over deze editie toe",
 			"in-playlists": "In afspeellijsten | In afspeellijst | In afspeellijsten",
+			"merge": "Albums samenvoegen",
+			"merge-into": "Voeg {obj} samen met",
 			"new": "Nieuw album",
 			"no-tracks-to-play": "Er zijn geen nummers om af te spelen",
 			"no-tracks-to-add": "Er zijn geen nummers om toe te voegen",

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -166,6 +166,17 @@ export default {
         return false;
       }
     },
+    async merge({ commit, rootState }, { newID, oldID }) {
+      try {
+        await api.albums.merge(rootState.auth, newID, oldID);
+        commit("tracks/updateAlbumOccurence", { newID, oldID }, { root: true });
+        commit("removeAlbum", oldID);
+        return true;
+      } catch (error) {
+        commit("addError", error, { root: true });
+        return false;
+      }
+    },
   },
   getters: {
     albums: (state) => Object.values(state.albums),

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -47,6 +47,16 @@ export default {
         }
       }
     },
+    updateAlbumOccurence(state, { newID, oldID }) {
+      const oldTracks = state.tracks;
+      state.tracks = {};
+      for (const track of Object.values(oldTracks)) {
+        if (track.album_id == oldID) {
+          track.album_id = newID;
+        }
+        state.tracks[track.id] = track;
+      }
+    },
     removeArtistOccurence(state, oldID) {
       const oldTracks = state.tracks;
       state.tracks = {};


### PR DESCRIPTION
Allow moderators and admins to merge albums.

I tested this manually.

~~NOTE: The matching PRs accentor/api#426 and accentor/api-client-js#157 were merged, but have not been released yet.
We should have a release of those first, before this can be merged.~~
