### PR TITLE
Always set hidden when updating track artists through mass edit

### DIFF
--- a/src/components/MassEditDialog.vue
+++ b/src/components/MassEditDialog.vue
@@ -486,16 +486,17 @@ export default {
             transformed.track_artists = transformedArtists;
           } else {
             transformedArtists.forEach((a) => {
-              if (
-                transformed.track_artists.filter(
-                  (ta) =>
-                    ta.name === a.name &&
-                    ta.role === a.role &&
-                    ta.artist_id === a.artist_id
-                ).length === 0
-              ) {
+              const index = transformed.track_artists.findIndex(
+                (ta) =>
+                  ta.name === a.name &&
+                  ta.role === a.role &&
+                  ta.artist_id === a.artist_id
+              );
+              if (index === -1) {
                 a.order += t.track_artists.length;
                 transformed.track_artists.push(a);
+              } else {
+                transformed.track_artists[index].hidden = a.hidden;
               }
             });
           }


### PR DESCRIPTION
I've noticed that I sometimes forget to set `hidden` when updating multiple tracks at once. This can be annoying, since I then either need to:
* Start again with updating the tracks
* Update each track to set the artist(s) to hidden

I think it might be more useful to be able to switch the `hidden` status through the mass edit.

(Note: I considered if we should also do this for the track artist's name, but thought it to be conflicting with the way we leave that field as optional)