### PR TITLE
Automatically load node modules in devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,39 +21,43 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; overlays = [ devshell.overlays.default ]; };
+        web-package = pkgs.mkYarnPackage {
+          pname = "accentor-web";
+          version = "0.32.0";
+
+          src = pkgs.lib.cleanSourceWith { filter = name: type: !(builtins.elem name [ ".github" "flake.lock" "flake.nix" ]); src = ./.; name = "source"; };
+          packageJSON = ./package.json;
+          yarnLock = ./yarn.lock;
+          yarnNix = ./yarn.nix;
+
+          # Otherwise this tries to write to read-only paths, and caching is unnecessary anyway.
+          SKIP_CACHE = "true";
+          buildPhase = ''
+            cp deps/accentor/postcss.config.js .
+            yarn run build
+          '';
+
+          installPhase = ''
+            cp -r deps/accentor/dist $out
+            rm $out/**/*.map
+          '';
+
+          distPhase = "true";
+        };
       in
       {
-        packages = rec {
-          default = accentor-web;
-          accentor-web = pkgs.mkYarnPackage rec {
-            pname = "accentor-web";
-            version = "0.32.0";
-
-            src = pkgs.lib.cleanSourceWith { filter = name: type: !(builtins.elem name [ ".github" "flake.lock" "flake.nix" ]); src = ./.; name = "source"; };
-            packageJSON = ./package.json;
-            yarnLock = ./yarn.lock;
-            yarnNix = ./yarn.nix;
-
-            # Otherwise this tries to write to read-only paths, and caching is unnecessary anyway.
-            SKIP_CACHE = "true";
-            buildPhase = ''
-              cp deps/accentor/postcss.config.js .
-              yarn run build
-            '';
-
-            installPhase = ''
-              cp -r deps/accentor/dist $out
-              rm $out/**/*.map
-            '';
-
-            distPhase = "true";
-          };
+        packages = {
+          default = web-package;
+          accentor-web = web-package;
         };
 
         devShells = rec {
           default = accentor-web;
           accentor-web = pkgs.devshell.mkShell {
             name = "Accentor Web";
+            devshell.startup.link-node-modules.text = ''
+              ln -sf ${web-package.deps}/node_modules $PRJ_ROOT/node_modules
+            '';
             packages = with pkgs; [
               nixpkgs-fmt
               yarn2nix


### PR DESCRIPTION
This PR makes sure that loading the devshell (using direnv or nix develop) automatically includes the node modules.