### PR TITLE
Provide a download button for track

### DIFF
--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -115,6 +115,19 @@
             </VListItem>
           </VList>
         </VMenu>
+        <VListItem
+          v-if="track.length"
+          :href="downloadURL"
+          download
+          target="_blank"
+        >
+          <VListItemIcon>
+            <VIcon color="info">mdi-download</VIcon>
+          </VListItemIcon>
+          <VListItemContent>
+            <VListItemTitle>{{ $t("music.track.download") }}</VListItemTitle>
+          </VListItemContent>
+        </VListItem>
         <VTooltip bottom :disabled="!waitingForReload">
           <template v-slot:activator="{ on }">
             <VListItem
@@ -183,6 +196,7 @@
 
 <script>
 import { mapActions, mapGetters, mapState } from "vuex";
+import { baseURL } from "../api";
 import EditReviewComment from "./EditReviewComment";
 
 import AddToPlaylist from "./AddToPlaylist";
@@ -195,11 +209,15 @@ export default {
   },
   computed: {
     ...mapGetters("auth", ["isModerator"]),
+    ...mapState("auth", ["secret", "device_id"]),
     ...mapState("tracks", ["startLoading"]),
     ...mapState("codecs", ["codecs"]),
     ...mapState("locations", ["locations"]),
     waitingForReload() {
       return this.startLoading > this.track.loaded;
+    },
+    downloadURL() {
+      return `${baseURL}/tracks/${this.track.id}/download?secret=${this.secret}&device_id=${this.device_id}`;
     },
   },
   methods: {

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -38,14 +38,14 @@
     </VTooltip>
     <AddToPlaylist :item="track" type="track" />
     <EditReviewComment :item="track" :update="flag" />
-    <VMenu v-if="isModerator">
+    <VMenu>
       <template v-slot:activator="{ on, attrs }">
         <VBtn class="actions__button mr-0" small icon v-bind="attrs" v-on="on">
           <VIcon>mdi-dots-vertical</VIcon>
         </VBtn>
       </template>
       <VList dense>
-        <VMenu open-on-hover offset-x left v-if="track.length">
+        <VMenu open-on-hover offset-x left v-if="track.length && isModerator">
           <template v-slot:activator="{ on }">
             <VListItem v-on="on">
               <VListItemIcon v-on="on">
@@ -128,7 +128,7 @@
             <VListItemTitle>{{ $t("music.track.download") }}</VListItemTitle>
           </VListItemContent>
         </VListItem>
-        <VTooltip bottom :disabled="!waitingForReload">
+        <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
           <template v-slot:activator="{ on }">
             <VListItem
               :to="{
@@ -149,7 +149,7 @@
           </template>
           <span>{{ $t("common.disabled-while-loading") }}</span>
         </VTooltip>
-        <VTooltip bottom :disabled="!waitingForReload">
+        <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
           <template v-slot:activator="{ on }">
             <VListItem
               :to="{
@@ -172,7 +172,7 @@
           </template>
           <span>{{ $t("common.disabled-while-loading") }}</span>
         </VTooltip>
-        <VTooltip bottom :disabled="!waitingForReload">
+        <VTooltip bottom :disabled="!waitingForReload" v-if="isModerator">
           <template v-slot:activator="{ on }">
             <VListItem
               @click.stop.prevent="deleteTrack"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -380,6 +380,7 @@
 			"bit_depth": "Bit depth",
 			"delete": "Delete track",
 			"delete-file-explanation": "Know that you have to remove the audio file as well. Otherwise this track will show up again on the next rescan.",
+			"download": "Download",
 			"edit": "Edit track",
 			"empty": "This track does not have audio.",
 			"file": "Audio file",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -380,6 +380,7 @@
 			"bit_depth": "Bit depth",
 			"delete": "Verwijder nummer",
 			"delete-file-explanation": "Weet dat je het audio bestand ook moet verwijderen. Anders duikt het nummer weer op bij de volgende scan.",
+			"download": "Download",
 			"edit": "Pas nummer aan",
 			"empty": "Dit nummer heeft geen audio.",
 			"file": "Audiobestand",


### PR DESCRIPTION
After the changes in [the api](https://github.com/accentor/api/pull/487), we can now provide a download button for the original audio.
This PR adds that button for moderators and admins (so it can be shown together with the audio file info)
