### PR TITLE
Make sure we mark playlist/items as dirty when item is removed

### DIFF
--- a/src/components/PlaylistForm.vue
+++ b/src/components/PlaylistForm.vue
@@ -94,7 +94,7 @@
                       icon
                       text
                       class="ma-2 red--text"
-                      @click="() => newPlaylist.item_ids.splice(index, 1)"
+                      @click="() => removeItem(index)"
                     >
                       <VIcon>mdi-close</VIcon>
                     </VBtn>
@@ -212,6 +212,11 @@ export default {
       this.newPlaylist.access = this.playlist.access;
       this.newPlaylist.playlist_type = this.playlist.playlist_type;
       this.newPlaylist.item_ids = [...this.playlist.item_ids];
+    },
+    removeItem(index) {
+      this.isDirty = true;
+      this.itemsDirty = true;
+      this.newPlaylist.item_ids.splice(index, 1);
     },
     async submit() {
       let pendingResult = null;


### PR DESCRIPTION
This PR fixes two (related) issues with the playlist form. When an item was removed, we didn't set `isDirty` and `itemsDirty`. This meant that:
* Updates to the playlist in the store would still change form's content
* An update where only items where removed would not be correctly sent to the api 