### PR TITLE
Add `application` to auth token params

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'"
   },
   "dependencies": {
-    "@accentor/api-client-js": "^0.20.1",
+    "@accentor/api-client-js": "^0.21.0",
     "@mdi/font": "^7.4.47",
     "@mdi/svg": "^7.4.47",
     "fetch-retry": "^6.0.0",

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import api from "@/api";
 import { fetchAll } from "./actions";
+import { APPLICATION_VERSION } from "../version";
 
 export default {
   namespaced: true,
@@ -56,7 +57,10 @@ export default {
   actions: {
     async login({ commit }, data) {
       try {
-        const result = await api.auth_tokens.create(data);
+        const result = await api.auth_tokens.create({
+          auth_token: { application: APPLICATION_VERSION },
+          ...data,
+        });
         commit("login", result);
         return true;
       } catch (error) {

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -1,7 +1,6 @@
 import Vue from "vue";
 import api from "@/api";
 import { fetchAll } from "./actions";
-import { APPLICATION_VERSION } from "../version";
 
 export default {
   namespaced: true,
@@ -58,7 +57,9 @@ export default {
     async login({ commit }, data) {
       try {
         const result = await api.auth_tokens.create({
-          auth_token: { application: APPLICATION_VERSION },
+          auth_token: {
+            application: process.env.APPLICATION_VERSION,
+          },
           ...data,
         });
         commit("login", result);

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,0 @@
-export const APPLICATION_VERSION = `WEB v${require("../package.json").version}`;

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,1 @@
+export const APPLICATION_VERSION = `WEB v${require("../package.json").version}`;

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,6 @@
+const version = require("./package.json").version;
+const webpack = require("webpack");
+
 module.exports = {
   pluginOptions: {
     i18n: {
@@ -16,6 +19,14 @@ module.exports = {
   },
   configureWebpack: (config) => {
     config.cache = process.env.SKIP_CACHE !== "true";
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        "process.env": {
+          // When building, this value will just be printed without quotes, so we add them explicitly
+          APPLICATION_VERSION: `"Accentor Web v${version}"`,
+        },
+      }),
+    );
   },
   chainWebpack: (config) => {
     config.module

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@accentor/api-client-js@^0.20.1":
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/@accentor/api-client-js/-/api-client-js-0.20.1.tgz#1fddf9e6e999f78f597930464b6abf474da6a2fc"
-  integrity sha512-rZRbCZuJjFfN4d+PVctQFK9t38LJabLndGNxOGgbeGUkkliHvLNYWhC1BIqrxLDcstED6LO6h0huhq0Pw83QLA==
+"@accentor/api-client-js@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@accentor/api-client-js/-/api-client-js-0.21.0.tgz#e7270eb867d91708bc81202fc8aa0ba1c339a4f1"
+  integrity sha512-UsDbjHznV6bdqmkSILHrz5fH79WCVzvxa2oFQHoTU4NbOW9SCmcsCSmZXOXo7AN14TCrVPbgBYCJaAoaZgqQFQ==
   dependencies:
     fetch-retry "^6.0.0"
 

--- a/yarn.nix
+++ b/yarn.nix
@@ -10,11 +10,11 @@
       };
     }
     {
-      name = "_accentor_api_client_js___api_client_js_0.20.1.tgz";
+      name = "_accentor_api_client_js___api_client_js_0.21.0.tgz";
       path = fetchurl {
-        name = "_accentor_api_client_js___api_client_js_0.20.1.tgz";
-        url  = "https://registry.yarnpkg.com/@accentor/api-client-js/-/api-client-js-0.20.1.tgz";
-        sha512 = "rZRbCZuJjFfN4d+PVctQFK9t38LJabLndGNxOGgbeGUkkliHvLNYWhC1BIqrxLDcstED6LO6h0huhq0Pw83QLA==";
+        name = "_accentor_api_client_js___api_client_js_0.21.0.tgz";
+        url  = "https://registry.yarnpkg.com/@accentor/api-client-js/-/api-client-js-0.21.0.tgz";
+        sha512 = "UsDbjHznV6bdqmkSILHrz5fH79WCVzvxa2oFQHoTU4NbOW9SCmcsCSmZXOXo7AN14TCrVPbgBYCJaAoaZgqQFQ==";
       };
     }
     {


### PR DESCRIPTION
This uses the new param from https://github.com/accentor/api/pull/622

I went with the format `WEB vX.Y.Z` but am open to other suggestions.

Manual tests:
* Logging in creates an auth token with the appropriate `application` attribute
* Running `yarn build` creates a bundle that directly contains the version from `package.json`