### PR TITLE
Replace random sort with deterministic "random"

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -269,6 +269,8 @@ import {
   compareStrings,
 } from "../comparators";
 
+const RANDOM_SEED_MAX = 10_000;
+
 export default {
   name: "Home",
   components: { AlbumCard, ArtistCard },
@@ -292,12 +294,10 @@ export default {
       return artists.sort(compareByRecentlyPlayed(this.playStatsByArtist));
     },
     randomSort(items) {
-      const newItems = [...items];
-      for (let i = newItems.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [newItems[i], newItems[j]] = [newItems[j], newItems[i]];
-      }
-      return newItems;
+      return items.sort(
+        (i1, i2) =>
+          Math.sin(i2.id + this.randomSeed) - Math.sin(i1.id + this.randomSeed),
+      );
     },
   },
   computed: {
@@ -308,6 +308,9 @@ export default {
       playStatsByAlbum: "plays/playStatsByAlbum",
       playStatsByArtist: "plays/playStatsByArtist",
     }),
+    randomSeed() {
+      return Math.round(Math.random() * RANDOM_SEED_MAX);
+    },
     randomAlbums() {
       return this.randomSort(this.albums);
     },


### PR DESCRIPTION
This PR replaces our random sort with a "random" sort based `sin(id + RANDOM_SEED)`. The random seed gets assigned every time the home view opens. This makes the home view less jumpy, as the items in the random rows won't update every single time the albums/artists are updated (unless there are a lot of additions or deletions in the array). 

There are obviously ways of doing this that would provide better randomness. I went with this approach, since we can also use this function in SQL with `order(SIN(id + ?))` (as I did in [the iOS/macOS app](https://github.com/accentor/ios_macos/blob/main/accentor/Model/Artist.swift#L80-L88)) and can provide a similar experience in all environments.