### PR TITLE
Make sure random sort does not mutate array

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -294,7 +294,7 @@ export default {
       return artists.sort(compareByRecentlyPlayed(this.playStatsByArtist));
     },
     randomSort(items) {
-      return items.sort(
+      return [...items].sort(
         (i1, i2) =>
           Math.sin(i2.id + this.randomSeed) - Math.sin(i1.id + this.randomSeed),
       );


### PR DESCRIPTION
This PR fixes a small isue where the artists' overview would use the random sort from home. We now always clone the array before sorting, so that we don't mutate the original array.

I did a manual test to recreate the issue and then verify that I couldn't recreate the issue