### PR TITLE
Switch authorization to new token system

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'"
   },
   "dependencies": {
-    "@accentor/api-client-js": "^0.21.0",
+    "@accentor/api-client-js": "^0.23.0",
     "@mdi/font": "^7.4.47",
     "@mdi/svg": "^7.4.47",
     "fetch-retry": "^6.0.0",

--- a/src/components/TrackActions.vue
+++ b/src/components/TrackActions.vue
@@ -209,7 +209,7 @@ export default {
   },
   computed: {
     ...mapGetters("auth", ["isModerator"]),
-    ...mapState("auth", ["secret", "device_id"]),
+    ...mapState("auth", ["apiToken"]),
     ...mapState("tracks", ["startLoading"]),
     ...mapState("codecs", ["codecs"]),
     ...mapState("locations", ["locations"]),
@@ -217,7 +217,7 @@ export default {
       return this.startLoading > this.track.loaded;
     },
     downloadURL() {
-      return `${baseURL}/tracks/${this.track.id}/download?secret=${this.secret}&device_id=${this.device_id}`;
+      return `${baseURL}/tracks/${this.track.id}/download?token=${this.apiToken}`;
     },
   },
   methods: {

--- a/src/store/albums.js
+++ b/src/store/albums.js
@@ -101,7 +101,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }, scope = new AlbumsScope()) {
-      const generator = api.albums.index(rootState.auth, scope);
+      const generator = api.albums.index(rootState.auth.apiToken, scope);
       try {
         await this.albumsRestored;
         await fetchAll(commit, generator, "setAlbums", scope);
@@ -113,7 +113,7 @@ export default {
     },
     async create({ commit, rootState }, newAlbum) {
       try {
-        const result = await api.albums.create(rootState.auth, {
+        const result = await api.albums.create(rootState.auth.apiToken, {
           album: newAlbum,
         });
         commit("setAlbum", { id: result.id, album: result });
@@ -125,7 +125,7 @@ export default {
     },
     async read({ commit, rootState }, id) {
       try {
-        const result = await api.albums.read(rootState.auth, id);
+        const result = await api.albums.read(rootState.auth.apiToken, id);
         await this.albumsRestored;
         commit("setAlbum", { id, album: result });
         return result.id;
@@ -136,7 +136,7 @@ export default {
     },
     async update({ commit, rootState }, { id, newAlbum }) {
       try {
-        const result = await api.albums.update(rootState.auth, id, {
+        const result = await api.albums.update(rootState.auth.apiToken, id, {
           album: newAlbum,
         });
         commit("setAlbum", { id, album: result });
@@ -148,7 +148,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.albums.destroy(rootState.auth, id);
+        await api.albums.destroy(rootState.auth.apiToken, id);
         commit("removeAlbum", id);
         return true;
       } catch (error) {
@@ -158,7 +158,7 @@ export default {
     },
     async destroyEmpty({ commit, dispatch, rootState }) {
       try {
-        await api.albums.destroyEmpty(rootState.auth);
+        await api.albums.destroyEmpty(rootState.auth.apiToken);
         await dispatch("index");
         return true;
       } catch (error) {
@@ -168,7 +168,7 @@ export default {
     },
     async merge({ commit, rootState }, { newID, oldID }) {
       try {
-        await api.albums.merge(rootState.auth, newID, oldID);
+        await api.albums.merge(rootState.auth.apiToken, newID, oldID);
         commit("tracks/updateAlbumOccurence", { newID, oldID }, { root: true });
         commit("removeAlbum", oldID);
         return true;

--- a/src/store/artists.js
+++ b/src/store/artists.js
@@ -50,7 +50,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }, scope = new ArtistsScope()) {
-      const generator = api.artists.index(rootState.auth, scope);
+      const generator = api.artists.index(rootState.auth.apiToken, scope);
       try {
         await this.artistsRestored;
         await fetchAll(commit, generator, "setArtists", scope);
@@ -62,7 +62,7 @@ export default {
     },
     async create({ commit, rootState }, newArtist) {
       try {
-        const result = await api.artists.create(rootState.auth, {
+        const result = await api.artists.create(rootState.auth.apiToken, {
           artist: newArtist,
         });
         commit("setArtist", { id: result.id, artist: result });
@@ -74,7 +74,7 @@ export default {
     },
     async read({ commit, rootState }, id) {
       try {
-        const result = await api.artists.read(rootState.auth, id);
+        const result = await api.artists.read(rootState.auth.apiToken, id);
         await this.artistsRestored;
         commit("setArtist", { id, artist: result });
         return result.id;
@@ -85,7 +85,7 @@ export default {
     },
     async update({ commit, rootState }, { id, newArtist }) {
       try {
-        const result = await api.artists.update(rootState.auth, id, {
+        const result = await api.artists.update(rootState.auth.apiToken, id, {
           artist: newArtist,
         });
         commit("setArtist", { id, artist: result });
@@ -97,7 +97,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.artists.destroy(rootState.auth, id);
+        await api.artists.destroy(rootState.auth.apiToken, id);
         commit("albums/removeArtistOccurence", id, { root: true });
         commit("tracks/removeArtistOccurence", id, { root: true });
         commit("removeArtist", id);
@@ -109,7 +109,7 @@ export default {
     },
     async destroyEmpty({ commit, dispatch, rootState }) {
       try {
-        await api.artists.destroyEmpty(rootState.auth);
+        await api.artists.destroyEmpty(rootState.auth.apiToken);
         await dispatch("index");
         return true;
       } catch (error) {
@@ -119,7 +119,7 @@ export default {
     },
     async merge({ commit, rootState }, { newID, oldID }) {
       try {
-        await api.artists.merge(rootState.auth, newID, oldID);
+        await api.artists.merge(rootState.auth.apiToken, newID, oldID);
         commit(
           "tracks/updateArtistOccurence",
           { newID, oldID },

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -6,22 +6,19 @@ export default {
   namespaced: true,
   state: {
     authTokens: {},
-    device_id: null,
-    secret: null,
+    apiToken: null,
     user_id: null,
     id: null,
     startLoading: new Date(0),
   },
   mutations: {
     login(state, payload) {
-      state.device_id = payload.device_id;
-      state.secret = payload.secret;
+      state.apiToken = payload.token;
       state.user_id = payload.user_id;
       state.id = payload.id;
     },
     logout(state) {
-      state.device_id = null;
-      state.secret = null;
+      state.apiToken = null;
       state.user_id = null;
       state.id = null;
     },
@@ -80,7 +77,7 @@ export default {
       }
     },
     async index({ commit, rootState }) {
-      const generator = api.auth_tokens.index(rootState.auth);
+      const generator = api.auth_tokens.index(rootState.auth.apiToken);
       try {
         await fetchAll(commit, generator, "setAuthTokens");
         return true;
@@ -91,7 +88,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.auth_tokens.destroy(rootState.auth, id);
+        await api.auth_tokens.destroy(rootState.auth.apiToken, id);
         commit("removeAuthToken", id);
         return true;
       } catch (error) {
@@ -104,7 +101,7 @@ export default {
     authTokens: (state) =>
       Object.values(state.authTokens).sort((a1, a2) => a1.id - a2.id),
     loggedIn: (state) => {
-      return state.secret !== null && state.device_id !== null;
+      return state.apiToken !== null;
     },
     currentSession: (state) => {
       return state.id;

--- a/src/store/codec_conversions.js
+++ b/src/store/codec_conversions.js
@@ -48,7 +48,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }) {
-      const generator = api.codec_conversions.index(rootState.auth);
+      const generator = api.codec_conversions.index(rootState.auth.apiToken);
       try {
         await fetchAll(commit, generator, "setCodecConversions");
         return true;
@@ -59,9 +59,12 @@ export default {
     },
     async create({ commit, rootState }, newCodecConversion) {
       try {
-        const result = await api.codec_conversions.create(rootState.auth, {
-          codec_conversion: newCodecConversion,
-        });
+        const result = await api.codec_conversions.create(
+          rootState.auth.apiToken,
+          {
+            codec_conversion: newCodecConversion,
+          },
+        );
         commit("setCodecConversion", {
           id: result.id,
           codecConversion: result,
@@ -74,9 +77,13 @@ export default {
     },
     async update({ commit, rootState }, { id, newCodecConversion }) {
       try {
-        const result = await api.codec_conversions.update(rootState.auth, id, {
-          codec_conversion: newCodecConversion,
-        });
+        const result = await api.codec_conversions.update(
+          rootState.auth.apiToken,
+          id,
+          {
+            codec_conversion: newCodecConversion,
+          },
+        );
         commit("setCodecConversion", { id, codecConversion: result });
         return true;
       } catch (error) {
@@ -86,7 +93,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.codec_conversions.destroy(rootState.auth, id);
+        await api.codec_conversions.destroy(rootState.auth.apiToken, id);
         commit("removeCodecConversion", id);
         return true;
       } catch (error) {

--- a/src/store/codecs.js
+++ b/src/store/codecs.js
@@ -48,7 +48,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }) {
-      const generator = api.codecs.index(rootState.auth);
+      const generator = api.codecs.index(rootState.auth.apiToken);
       try {
         await fetchAll(commit, generator, "setCodecs");
         return true;
@@ -59,7 +59,7 @@ export default {
     },
     async create({ commit, rootState }, newCodec) {
       try {
-        const result = await api.codecs.create(rootState.auth, {
+        const result = await api.codecs.create(rootState.auth.apiToken, {
           codec: newCodec,
         });
         commit("setCodec", { id: result.id, codec: result });
@@ -71,7 +71,7 @@ export default {
     },
     async update({ commit, rootState }, { id, newCodec }) {
       try {
-        const result = await api.codecs.update(rootState.auth, id, {
+        const result = await api.codecs.update(rootState.auth.apiToken, id, {
           codec: newCodec,
         });
         commit("setCodec", { id, codec: result });
@@ -83,7 +83,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.codecs.destroy(rootState.auth, id);
+        await api.codecs.destroy(rootState.auth.apiToken, id);
         commit("removeCodec", id);
         return true;
       } catch (error) {

--- a/src/store/cover_filenames.js
+++ b/src/store/cover_filenames.js
@@ -48,7 +48,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }) {
-      const generator = api.cover_filenames.index(rootState.auth);
+      const generator = api.cover_filenames.index(rootState.auth.apiToken);
       try {
         await fetchAll(commit, generator, "setCoverFilenames");
         return true;
@@ -60,7 +60,7 @@ export default {
     async create({ commit, rootState }, newCoverFilename) {
       try {
         const result = await api.cover_filenames.create(
-          rootState.auth,
+          rootState.auth.apiToken,
           newCoverFilename,
         );
         commit("setCoverFilename", { id: result.id, coverFilename: result });
@@ -73,7 +73,7 @@ export default {
     async update({ commit, rootState }, { id, newCoverFilename }) {
       try {
         const result = await api.cover_filenames.update(
-          rootState.auth,
+          rootState.auth.apiToken,
           id,
           newCoverFilename,
         );
@@ -86,7 +86,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.cover_filenames.destroy(rootState.auth, id);
+        await api.cover_filenames.destroy(rootState.auth.apiToken, id);
         commit("removeCoverFilename", id);
         return true;
       } catch (error) {

--- a/src/store/genres.js
+++ b/src/store/genres.js
@@ -49,7 +49,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }) {
-      const generator = api.genres.index(rootState.auth);
+      const generator = api.genres.index(rootState.auth.apiToken);
       try {
         await this.genresRestored;
         await fetchAll(commit, generator, "setGenres");
@@ -61,7 +61,7 @@ export default {
     },
     async create({ commit, rootState }, newGenre) {
       try {
-        const result = await api.genres.create(rootState.auth, {
+        const result = await api.genres.create(rootState.auth.apiToken, {
           genre: newGenre,
         });
         commit("setGenre", { id: result.id, genre: result });
@@ -73,7 +73,7 @@ export default {
     },
     async read({ commit, rootState }, id) {
       try {
-        const result = await api.genres.read(rootState.auth, id);
+        const result = await api.genres.read(rootState.auth.apiToken, id);
         await this.genresRestored;
         commit("setGenre", { id, genre: result });
         return result.id;
@@ -84,7 +84,7 @@ export default {
     },
     async update({ commit, rootState }, { id, newGenre }) {
       try {
-        const result = await api.genres.update(rootState.auth, id, {
+        const result = await api.genres.update(rootState.auth.apiToken, id, {
           genre: newGenre,
         });
         commit("setGenre", { id, genre: result });
@@ -96,7 +96,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.genres.destroy(rootState.auth, id);
+        await api.genres.destroy(rootState.auth.apiToken, id);
         commit("tracks/removeGenreOccurence", id, { root: true });
         commit("removeGenre", id);
         return true;
@@ -107,7 +107,7 @@ export default {
     },
     async destroyEmpty({ commit, dispatch, rootState }) {
       try {
-        await api.genres.destroyEmpty(rootState.auth);
+        await api.genres.destroyEmpty(rootState.auth.apiToken);
         await dispatch("index");
         return true;
       } catch (error) {
@@ -117,7 +117,7 @@ export default {
     },
     async merge({ commit, rootState }, { newID, oldID }) {
       try {
-        await api.genres.merge(rootState.auth, newID, oldID);
+        await api.genres.merge(rootState.auth.apiToken, newID, oldID);
         commit("tracks/updateGenreOccurence", { newID, oldID }, { root: true });
         commit("removeGenre", oldID);
         return true;

--- a/src/store/image_types.js
+++ b/src/store/image_types.js
@@ -48,7 +48,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }) {
-      const generator = api.image_types.index(rootState.auth);
+      const generator = api.image_types.index(rootState.auth.apiToken);
       try {
         await fetchAll(commit, generator, "setImageTypes");
         return true;
@@ -59,7 +59,7 @@ export default {
     },
     async create({ commit, rootState }, newImageType) {
       try {
-        const result = await api.image_types.create(rootState.auth, {
+        const result = await api.image_types.create(rootState.auth.apiToken, {
           image_type: newImageType,
         });
         commit("setImageType", { id: result.id, imageType: result });
@@ -71,9 +71,13 @@ export default {
     },
     async update({ commit, rootState }, { id, newImageType }) {
       try {
-        const result = await api.image_types.update(rootState.auth, id, {
-          image_type: newImageType,
-        });
+        const result = await api.image_types.update(
+          rootState.auth.apiToken,
+          id,
+          {
+            image_type: newImageType,
+          },
+        );
         commit("setImageType", { id, imageType: result });
         return true;
       } catch (error) {
@@ -83,7 +87,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.image_types.destroy(rootState.auth, id);
+        await api.image_types.destroy(rootState.auth.apiToken, id);
         commit("removeImageType", id);
         return true;
       } catch (error) {

--- a/src/store/labels.js
+++ b/src/store/labels.js
@@ -49,7 +49,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }) {
-      const generator = api.labels.index(rootState.auth);
+      const generator = api.labels.index(rootState.auth.apiToken);
       try {
         await this.labelsRestored;
         await fetchAll(commit, generator, "setLabels");
@@ -61,7 +61,7 @@ export default {
     },
     async create({ commit, rootState }, newLabel) {
       try {
-        const result = await api.labels.create(rootState.auth, {
+        const result = await api.labels.create(rootState.auth.apiToken, {
           label: newLabel,
         });
         commit("setLabel", { id: result.id, label: result });
@@ -73,7 +73,7 @@ export default {
     },
     async read({ commit, rootState }, id) {
       try {
-        const result = await api.labels.read(rootState.auth, id);
+        const result = await api.labels.read(rootState.auth.apiToken, id);
         await this.labelsRestored;
         commit("setLabel", { id, label: result });
         return result.id;
@@ -84,7 +84,7 @@ export default {
     },
     async update({ commit, rootState }, { id, newLabel }) {
       try {
-        const result = await api.labels.update(rootState.auth, id, {
+        const result = await api.labels.update(rootState.auth.apiToken, id, {
           label: newLabel,
         });
         commit("setLabel", { id, label: result });
@@ -96,7 +96,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.labels.destroy(rootState.auth, id);
+        await api.labels.destroy(rootState.auth.apiToken, id);
         commit("albums/removeLabelOccurence", id, { root: true });
         commit("removeLabel", id);
         return true;
@@ -107,7 +107,7 @@ export default {
     },
     async destroyEmpty({ commit, dispatch, rootState }) {
       try {
-        await api.labels.destroyEmpty(rootState.auth);
+        await api.labels.destroyEmpty(rootState.auth.apiToken);
         await dispatch("index");
         return true;
       } catch (error) {
@@ -117,7 +117,7 @@ export default {
     },
     async merge({ commit, rootState }, { newID, oldID }) {
       try {
-        await api.labels.merge(rootState.auth, newID, oldID);
+        await api.labels.merge(rootState.auth.apiToken, newID, oldID);
         commit("albums/updateLabelOccurence", { newID, oldID }, { root: true });
         commit("removeLabel", oldID);
         return true;

--- a/src/store/locations.js
+++ b/src/store/locations.js
@@ -48,7 +48,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }) {
-      const generator = api.locations.index(rootState.auth);
+      const generator = api.locations.index(rootState.auth.apiToken);
       try {
         await fetchAll(commit, generator, "setLocations");
         return true;
@@ -59,7 +59,7 @@ export default {
     },
     async create({ commit, rootState }, newLocation) {
       try {
-        const result = await api.locations.create(rootState.auth, {
+        const result = await api.locations.create(rootState.auth.apiToken, {
           location: newLocation,
         });
         commit("setLocation", { id: result.id, location: result });
@@ -71,7 +71,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.locations.destroy(rootState.auth, id);
+        await api.locations.destroy(rootState.auth.apiToken, id);
         commit("removeLocation", id);
         return true;
       } catch (error) {

--- a/src/store/player.js
+++ b/src/store/player.js
@@ -154,11 +154,10 @@ export default {
       return state.current >= 0 ? getters.playlistTracks[state.current] : null;
     },
     currentTrackURL(state, getters, rootState, rootGetters) {
-      const secret = rootState.auth.secret;
-      const device_id = rootState.auth.device_id;
+      const apiToken = rootState.auth.apiToken;
       const codecConversion =
         rootGetters["userSettings/codecConversion"]?.id ?? "";
-      const params = `/audio?secret=${secret}&device_id=${device_id}&codec_conversion_id=${codecConversion}`;
+      const params = `/audio?token=${apiToken}&codec_conversion_id=${codecConversion}`;
       const tracks = `${baseURL}/tracks/`;
       return (
         getters.currentTrack && `${tracks}${getters.currentTrack.id}${params}`

--- a/src/store/playlists.js
+++ b/src/store/playlists.js
@@ -49,7 +49,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }) {
-      const generator = api.playlists.index(rootState.auth);
+      const generator = api.playlists.index(rootState.auth.apiToken);
       try {
         await fetchAll(commit, generator, "setPlaylists");
         return true;
@@ -60,7 +60,7 @@ export default {
     },
     async create({ commit, rootState }, newPlaylist) {
       try {
-        const result = await api.playlists.create(rootState.auth, {
+        const result = await api.playlists.create(rootState.auth.apiToken, {
           playlist: newPlaylist,
         });
         commit("setPlaylist", { id: result.id, playlist: result });
@@ -72,7 +72,7 @@ export default {
     },
     async read({ commit, rootState }, id) {
       try {
-        const result = await api.playlists.read(rootState.auth, id);
+        const result = await api.playlists.read(rootState.auth.apiToken, id);
         commit("setPlaylist", { id, playlist: result });
         return result.id;
       } catch (error) {
@@ -82,7 +82,7 @@ export default {
     },
     async update({ commit, rootState }, { id, newPlaylist }) {
       try {
-        const result = await api.playlists.update(rootState.auth, id, {
+        const result = await api.playlists.update(rootState.auth.apiToken, id, {
           playlist: newPlaylist,
         });
         commit("setPlaylist", { id, playlist: result });
@@ -94,7 +94,7 @@ export default {
     },
     async addItem({ commit, rootState, dispatch }, { id, newItem }) {
       try {
-        await api.playlists.addItem(rootState.auth, id, {
+        await api.playlists.addItem(rootState.auth.apiToken, id, {
           playlist: newItem,
         });
         await dispatch("read", id);
@@ -105,7 +105,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.playlists.destroy(rootState.auth, id);
+        await api.playlists.destroy(rootState.auth.apiToken, id);
         commit("removePlaylist", id);
         return true;
       } catch (error) {

--- a/src/store/plays.js
+++ b/src/store/plays.js
@@ -45,7 +45,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }, scope = new TracksScope()) {
-      const generator = api.plays.index(rootState.auth, scope);
+      const generator = api.plays.index(rootState.auth.apiToken, scope);
       try {
         await this.playsRestored;
         await fetchAll(commit, generator, "setPlays", scope);
@@ -57,7 +57,7 @@ export default {
     },
     async create({ commit, rootState }, track_id) {
       try {
-        const result = await api.plays.create(rootState.auth, {
+        const result = await api.plays.create(rootState.auth.apiToken, {
           play: {
             track_id,
             played_at: new Date(),

--- a/src/store/rescan.js
+++ b/src/store/rescan.js
@@ -57,7 +57,7 @@ export default {
       try {
         commit("setLoading", true);
         do {
-          const generator = api.rescans.index(rootState.auth);
+          const generator = api.rescans.index(rootState.auth.apiToken);
           await fetchAll(commit, generator, "setRescans");
           await new Promise((resolve) => setTimeout(resolve, 1000));
         } while (
@@ -79,7 +79,7 @@ export default {
         commit("setLoading", true);
         let result = null;
         do {
-          result = await api.rescans.show(rootState.auth, id);
+          result = await api.rescans.show(rootState.auth.apiToken, id);
           commit("setRescan", { id, rescan: result });
           await new Promise((resolve) => setTimeout(resolve, 1000));
         } while (
@@ -97,7 +97,7 @@ export default {
     async startAll({ commit, dispatch, rootState }) {
       commit("setLastClick", new Date());
       try {
-        await api.rescans.startAll(rootState.auth);
+        await api.rescans.startAll(rootState.auth.apiToken);
         setTimeout(() => dispatch("index"), 2500);
         return true;
       } catch (error) {
@@ -108,7 +108,7 @@ export default {
     async start({ commit, dispatch, rootState }, id) {
       commit("setLastClick", new Date());
       try {
-        const result = await api.rescans.start(rootState.auth, id);
+        const result = await api.rescans.start(rootState.auth.apiToken, id);
         result.running = true;
         commit("setRescan", { id, rescan: result });
         setTimeout(() => dispatch("show", id), 1000);

--- a/src/store/tracks.js
+++ b/src/store/tracks.js
@@ -111,7 +111,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }, scope = new TracksScope()) {
-      const generator = api.tracks.index(rootState.auth, scope);
+      const generator = api.tracks.index(rootState.auth.apiToken, scope);
       try {
         await this.tracksRestored;
         await fetchAll(commit, generator, "setTracks", scope);
@@ -123,7 +123,7 @@ export default {
     },
     async create({ commit, rootState }, newTrack) {
       try {
-        const result = await api.tracks.create(rootState.auth, {
+        const result = await api.tracks.create(rootState.auth.apiToken, {
           track: newTrack,
         });
         commit("setTrack", { id: result.id, track: result });
@@ -135,7 +135,7 @@ export default {
     },
     async read({ commit, rootState }, id) {
       try {
-        const track = await api.tracks.read(rootState.auth, id);
+        const track = await api.tracks.read(rootState.auth.apiToken, id);
         await this.tracksRestored;
         commit("setTrack", { id, track });
         return true;
@@ -146,7 +146,7 @@ export default {
     },
     async update({ commit, rootState }, { id, newTrack }) {
       try {
-        const result = await api.tracks.update(rootState.auth, id, {
+        const result = await api.tracks.update(rootState.auth.apiToken, id, {
           track: newTrack,
         });
         commit("setTrack", { id, track: result });
@@ -158,7 +158,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.tracks.destroy(rootState.auth, id);
+        await api.tracks.destroy(rootState.auth.apiToken, id);
         commit("removeTrack", id);
         return true;
       } catch (error) {
@@ -168,7 +168,7 @@ export default {
     },
     async merge({ commit, dispatch, rootState }, { newID, oldID }) {
       try {
-        await api.tracks.merge(rootState.auth, newID, oldID);
+        await api.tracks.merge(rootState.auth.apiToken, newID, oldID);
         await dispatch("read", newID);
         commit("removeTrack", oldID);
         return true;

--- a/src/store/users.js
+++ b/src/store/users.js
@@ -49,7 +49,7 @@ export default {
   },
   actions: {
     async index({ commit, rootState }) {
-      const generator = api.users.index(rootState.auth);
+      const generator = api.users.index(rootState.auth.apiToken);
       try {
         await fetchAll(commit, generator, "setUsers");
         return true;
@@ -60,7 +60,7 @@ export default {
     },
     async create({ commit, rootState }, newUser) {
       try {
-        const result = await api.users.create(rootState.auth, {
+        const result = await api.users.create(rootState.auth.apiToken, {
           user: newUser,
         });
         commit("setUser", { id: result.id, user: result });
@@ -72,7 +72,7 @@ export default {
     },
     async update({ commit, rootState }, { id, newUser }) {
       try {
-        const result = await api.users.update(rootState.auth, id, {
+        const result = await api.users.update(rootState.auth.apiToken, id, {
           user: newUser,
         });
         commit("setUser", { id, user: result });
@@ -84,7 +84,7 @@ export default {
     },
     async destroy({ commit, rootState }, id) {
       try {
-        await api.users.destroy(rootState.auth, id);
+        await api.users.destroy(rootState.auth.apiToken, id);
         commit("removeUser", id);
         return true;
       } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@accentor/api-client-js@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@accentor/api-client-js/-/api-client-js-0.21.0.tgz#e7270eb867d91708bc81202fc8aa0ba1c339a4f1"
-  integrity sha512-UsDbjHznV6bdqmkSILHrz5fH79WCVzvxa2oFQHoTU4NbOW9SCmcsCSmZXOXo7AN14TCrVPbgBYCJaAoaZgqQFQ==
+"@accentor/api-client-js@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@accentor/api-client-js/-/api-client-js-0.23.0.tgz#610f2b22d5e4c941cec16383f9d91ac9c6e72829"
+  integrity sha512-Zii3x519nXWinloqC7t5wsYebnwMv01ENKrFtv3NUFRskE0+L7I+fL10P2Q9DUlQFzS/umMc6tyqXCLHP4av7A==
   dependencies:
     fetch-retry "^6.0.0"
 

--- a/yarn.nix
+++ b/yarn.nix
@@ -10,11 +10,11 @@
       };
     }
     {
-      name = "_accentor_api_client_js___api_client_js_0.21.0.tgz";
+      name = "_accentor_api_client_js___api_client_js_0.23.0.tgz";
       path = fetchurl {
-        name = "_accentor_api_client_js___api_client_js_0.21.0.tgz";
-        url  = "https://registry.yarnpkg.com/@accentor/api-client-js/-/api-client-js-0.21.0.tgz";
-        sha512 = "UsDbjHznV6bdqmkSILHrz5fH79WCVzvxa2oFQHoTU4NbOW9SCmcsCSmZXOXo7AN14TCrVPbgBYCJaAoaZgqQFQ==";
+        name = "_accentor_api_client_js___api_client_js_0.23.0.tgz";
+        url  = "https://registry.yarnpkg.com/@accentor/api-client-js/-/api-client-js-0.23.0.tgz";
+        sha512 = "Zii3x519nXWinloqC7t5wsYebnwMv01ENKrFtv3NUFRskE0+L7I+fL10P2Q9DUlQFzS/umMc6tyqXCLHP4av7A==";
       };
     }
     {


### PR DESCRIPTION
Depends on accentor/api#721
Depends on accentor/api-client-js#551 

Since this requires a new release of the api-client, I made this a draft PR so this can't be merged by accident.

This switches the web interface to use the new token system for authorization. Note that this will log all users out when refreshing.

I did a manual test to make sure that I could:
* Log in again
* Fetch data from the api
* Listen to a track