### PR TITLE
Fix auth param when loading stats

### DIFF
--- a/src/views/Stats.vue
+++ b/src/views/Stats.vue
@@ -156,7 +156,10 @@ export default {
       await this.$store.dispatch("plays/index");
     },
     async loadPlayStats() {
-      const gen = $api.plays.stats(this.$store.state.auth, this.playStatsScope);
+      const gen = $api.plays.stats(
+        this.$store.state.auth.apiToken,
+        this.playStatsScope,
+      );
       let done = false;
       let results = [];
       while (!done) {


### PR DESCRIPTION
In #1215 we updated the authorization logic to the new tokens. I forgot to switch the argument when loading the play stats (Resulting in an authorization header containing `Bearer [object Object]`. 

I double checked, but could not find any other cases where I forgot to switch the parameter. This is the only place outside of the stores were we access `state.auth` or interact with the api.

I manually tested the loading the stats now work 


<!---
  If you did any manual testing (please do so), describe here what you
  tested and how. Provide instructions so that your tests can be
  easily run again by a maintainer.
  --->
