### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,26 +9,20 @@ updates:
     timezone: Europe/Brussels
   open-pull-requests-limit: 10
   groups:
-    babel:
-      patterns:
-        - "@babel*"
-    mdi:
-      patterns:
-        - "@mdi/*"
-    vue:
-      patterns:
-        - "@?vue*"
     eslint:
       patterns:
         - "eslint*"
+    mdi:
+      patterns:
+        - "@mdi/*"
+    vite:
+      patterns:
+        - "@?vite*"
+    vue:
+      patterns:
+        - "@?vue*"
   ignore:
-    - dependency-name: "eslint-plugin-vue"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "eslint-plugin-vuetify"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "eslint"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "@vue/eslint-config-prettier"
+    - dependency-name: "@types/node"
       update-types: ["version-update:semver-major"]
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
This commit removes unused groups and ignores, and adds a new group for vite dependencies. It also adds a major version ignore for node.